### PR TITLE
captures exit codes in graph runs and exits accordingly

### DIFF
--- a/pkg/scenario_orchestrator/common_functions.go
+++ b/pkg/scenario_orchestrator/common_functions.go
@@ -65,7 +65,11 @@ func CommonRunGraph(scenarios models.ScenarioSet, resolvedGraph models.ResolvedG
 
 			go func() {
 				defer wg.Done()
-				_, _ = orchestrator.RunAttached(scenario.Image, containerName, env, cache, volumes, file, file, nil, ctx, registry)
+				_, err = orchestrator.RunAttached(scenario.Image, containerName, env, cache, volumes, file, file, nil, ctx, registry)
+				if err != nil {
+					commChannel <- &models.GraphCommChannel{Layer: &step, ScenarioId: &scId, ScenarioLogFile: &filename, Err: err}
+					return
+				}
 			}()
 
 		}


### PR DESCRIPTION
## Description  
captures exit codes in graph runs and exits accordingly

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  