### PR TITLE
[SCARF] krkn-chaos.dev vanity url

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
          export USERID=$(id -u)
          go test -tags containers_image_openpgp -race -json -v  -coverprofile=coverage.out ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
-         cat /tmp/gotest.log | go-ctrf-json-reporter -output ctrf-report.json
+         cat /tmp/gotest.log | go-ctrf-json-reporter -output ctrf-report.json > /dev/null
       - name: generate test report
         run: npx github-actions-ctrf ctrf-report.json
       - name: generate coverage report

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,11 +130,8 @@ func Execute(providerFactory *factory.ProviderFactory, scenarioOrchestrator *sce
 	}
 
 	if latestVersion != nil && *latestVersion != config.Version {
-		_, err = color.New(color.FgHiYellow).Println(fmt.Sprintf("📣📦 a newer version of krknctl, %s, is currently available, check it out! %s", *latestVersion, config.GithubLatestRelease))
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		// prints to stderr to not pollute output redirection on scaffold
+		println(color.YellowString("📣📦 a newer version of krknctl, %s, is currently available, check it out! %s", *latestVersion, config.GithubLatestRelease))
 	}
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -285,7 +285,7 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 			}
 			startTime := time.Now()
 			containerName := utils.GenerateContainerName(config, scenarioDetail.Name, nil)
-			quayImageUri, err := config.GetQuayImageUri()
+			quayImageUri, err := config.GetCustomDomainImageUri()
 			if err != nil {
 				return err
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	QuayBaseImageRegistry       string `json:"quay_base_image_registry"`
 	QuayBaseImageTag            string `json:"quay_base_image_tag"`
 	QuayRepositoryApi           string `json:"quay_repository_api"`
+	CustomDomainHost            string `json:"custom_domain_host"`
 	PrivateRegistryBaseImageTag string `json:"private_registry_base_image_tag"`
 	ContainerPrefix             string `json:"container_prefix"`
 	KubeconfigPrefix            string `json:"kubeconfig_prefix"`
@@ -68,6 +69,14 @@ func LoadConfig() (Config, error) {
 
 func (c *Config) GetQuayImageUri() (string, error) {
 	imageUri, err := url.JoinPath(c.QuayHost, c.QuayOrg, c.QuayScenarioRegistry)
+	if err != nil {
+		return "", err
+	}
+	return imageUri, nil
+}
+
+func (c *Config) GetCustomDomainImageUri() (string, error) {
+	imageUri, err := url.JoinPath(c.CustomDomainHost, c.QuayOrg, c.QuayScenarioRegistry)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/config.json
+++ b/pkg/config/config.json
@@ -6,6 +6,7 @@
   "quay_base_image_registry": "krkn",
   "quay_base_image_tag": "latest",
   "quay_repository_api": "api/v1/repository",
+  "custom_domain_host": "containers.krkn-chaos.dev",
   "private_registry_base_image_tag": "latest",
   "container_prefix": "krknctl",
   "kubeconfig_prefix": "krknctl-kubeconfig",

--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -102,7 +102,7 @@ func scaffoldScenarios(scenarios []string, includeGlobalEnv bool, registry *mode
 
 		var imageUri = ""
 		if registry == nil {
-			uri, err := config.GetQuayImageUri()
+			uri, err := config.GetCustomDomainImageUri()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description  
original quay.io image URIs replaced by containers.krkn-chaos.dev to enable usage statistics through [scarf.sh](https://scarf.sh)

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  