### PR TITLE
Output table output optimization

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -186,7 +186,10 @@ func NewGraphRunCommand(factory *providerfactory.ProviderFactory, scenarioOrches
 				return nil
 			}
 
-			table := NewGraphTable(executionPlan)
+			table, err := NewGraphTable(executionPlan, config)
+			if err != nil {
+				return err
+			}
 			table.Print()
 			fmt.Print("\n\n")
 			spinner.Suffix = "starting chaos scenarios..."

--- a/cmd/random.go
+++ b/cmd/random.go
@@ -194,7 +194,10 @@ func NewRandomRunCommand(factory *providerfactory.ProviderFactory, scenarioOrche
 				return nil
 			}
 
-			table := NewGraphTable(executionPlan)
+			table, err := NewGraphTable(executionPlan, config)
+			if err != nil {
+				return err
+			}
 			table.Print()
 			fmt.Print("\n\n")
 			spinner.Suffix = "starting chaos scenarios..."

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -268,7 +268,7 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 
 			spinner.Stop()
 
-			tbl := NewEnvironmentTable(parsedFields)
+			tbl := NewEnvironmentTable(parsedFields, config)
 			tbl.Print()
 			fmt.Print("\n")
 			// restarts the spinner to present image pull progress

--- a/cmd/tables_test.go
+++ b/cmd/tables_test.go
@@ -1,12 +1,97 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io"
 	"testing"
 )
 
 func TestNewEnvironmentTable(t *testing.T) {
 	config := getConfig(t)
-	values := map[string]ParsedField{"value": {"lkaslakslakslakslakslakslakslaksalsklaskaskl", false}}
+	longString := "lkaslakslakslakslakslakslakslaksalsklaskaskl"
+	values := map[string]ParsedField{"value": {longString, false}}
+	var buf bytes.Buffer
+	writer := io.Writer(&buf)
 	table := NewEnvironmentTable(values, config)
+	table = table.WithWriter(writer)
 	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer := buf.String()
+	assert.Contains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
+
+	buf.Reset()
+	shortString := longString[0:config.TableFieldMaxLength]
+	values = map[string]ParsedField{"value": {shortString, false}}
+	table = NewEnvironmentTable(values, config)
+	table = table.WithWriter(writer)
+	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer = buf.String()
+	assert.NotContains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
+	assert.Contains(t, stringBuffer, shortString)
+}
+
+func TestNewGraphTable(t *testing.T) {
+	graph := [][]string{
+		{
+			"application-outages-test-1",
+			"application-outages-test-2",
+			"application-outages-test-3",
+			"application-outages-test-4",
+			"application-outages-test-5",
+			"application-outages-test-6",
+		},
+		{
+			"node-cpu-hog-test-1",
+			"node-cpu-hog-test-2",
+			"node-cpu-hog-test-3",
+			"node-cpu-hog-test-4",
+			"node-cpu-hog-test-5",
+			"node-cpu-hog-test-6",
+			"node-cpu-hog-test-7",
+			"node-cpu-hog-test-8",
+		},
+		{
+			"do-not-exist-node-cpu-hog-test-1",
+			"do-not-exist-node-cpu-hog-test-2",
+			"do-not-exist-node-cpu-hog-test-3",
+			"do-not-exist-node-cpu-hog-test-4",
+			"do-not-exist-node-cpu-hog-test-5",
+			"do-not-exist-node-cpu-hog-test-6",
+			"do-not-exist-node-cpu-hog-test-7",
+			"do-not-exist-node-cpu-hog-test-8",
+			"example-1",
+			"example-2",
+		},
+
+		{
+			"affected",
+			"africa",
+			"alternative",
+			"alone",
+			"alias",
+			"afraid",
+			"although",
+			"always",
+		},
+	}
+
+	config := getConfig(t)
+
+	table, err := NewGraphTable(graph, config)
+	assert.Nil(t, err)
+	var buf bytes.Buffer
+	writer := io.Writer(&buf)
+	table = table.WithWriter(writer)
+	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer := buf.String()
+	assert.Contains(t, stringBuffer, "(8) node-cpu-hog-test")
+	assert.Contains(t, stringBuffer, "(8) do-not-exist-node-cpu-hog-test")
+	assert.Contains(t, stringBuffer, "(2) example")
+	assert.Contains(t, stringBuffer, "(3) af")
+	assert.Contains(t, stringBuffer, "(5) a")
+
 }

--- a/cmd/tables_test.go
+++ b/cmd/tables_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNewEnvironmentTable(t *testing.T) {
+	config := getConfig(t)
+	values := map[string]ParsedField{"value": {"lkaslakslakslakslakslakslakslaksalsklaskaskl", false}}
+	table := NewEnvironmentTable(values, config)
+	table.Print()
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	GithubReleaseAPI            string `json:"github_release_api"`
 	GithubReleaseAPIDeprecated  string `json:"github_release_api_deprecated"`
 	TableFieldMaxLength         int    `json:"table_field_max_length"`
+	TableMaxStepScenarioLength  int    `json:"table_max_step_scenario_length"`
 }
 
 //go:embed config.json

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	GithubLatestReleaseAPI      string `json:"github_latest_release_api"`
 	GithubReleaseAPI            string `json:"github_release_api"`
 	GithubReleaseAPIDeprecated  string `json:"github_release_api_deprecated"`
+	TableFieldMaxLength         int    `json:"table_field_max_length"`
 }
 
 //go:embed config.json

--- a/pkg/config/config.json
+++ b/pkg/config/config.json
@@ -45,5 +45,6 @@
   "github_latest_release": "https://github.com/krkn-chaos/krknctl/releases/latest",
   "github_latest_release_api": "https://api.github.com/repos/krkn-chaos/krknctl/releases/latest",
   "github_release_api": "https://api.github.com/repos/krkn-chaos/krknctl/releases/tags",
-  "github_release_api_deprecated": "[DEPRECATED]"
+  "github_release_api_deprecated": "[DEPRECATED]",
+  "table_field_max_length": 20
 }

--- a/pkg/config/config.json
+++ b/pkg/config/config.json
@@ -46,5 +46,6 @@
   "github_latest_release_api": "https://api.github.com/repos/krkn-chaos/krknctl/releases/latest",
   "github_release_api": "https://api.github.com/repos/krkn-chaos/krknctl/releases/tags",
   "github_release_api_deprecated": "[DEPRECATED]",
-  "table_field_max_length": 20
+  "table_field_max_length": 20,
+  "table_max_step_scenario_length": 7
 }


### PR DESCRIPTION
## Description  
in presence of very long output (long variables eg. base64 files) or a long list of scenarios (eg. random run with a large `--max-parallel` number of scenarios) the tables were overflowed by the content making them unreadable.

This change fixes this issue either truncating or grouping the output in the best way possible.

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  