### PR TITLE
feat:support flag to control log directory & handling kubeconfig duplicates

### DIFF
--- a/cmd/random.go
+++ b/cmd/random.go
@@ -206,7 +206,7 @@ func NewRandomRunCommand(factory *providerfactory.ProviderFactory, scenarioOrche
 			commChannel := make(chan *models.GraphCommChannel)
 
 			go func() {
-				(*scenarioOrchestrator).RunGraph(nodes, executionPlan, environment, volumes, false, commChannel, registrySettings, nil)
+				(*scenarioOrchestrator).RunGraph(nodes, executionPlan, environment, volumes, false, commChannel, registrySettings, nil, nil)
 			}()
 
 			for {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ func Execute(providerFactory *factory.ProviderFactory, scenarioOrchestrator *sce
 	graphRunCmd.Flags().String("alerts-profile", "", "custom alerts profile file path")
 	graphRunCmd.Flags().String("metrics-profile", "", "custom metrics profile file path")
 	graphRunCmd.Flags().Bool("exit-on-error", false, "if set this flag will the workflow will be interrupted and the tool will exit with a status greater than 0")
+	graphRunCmd.Flags().StringP("output", "o", "", "output directory for log files (default: current working directory)")
 	graphScaffoldCmd := NewGraphScaffoldCommand(providerFactory, config)
 	graphScaffoldCmd.Flags().Bool("global-env", false, "if set this flag will add global environment variables to each scenario in the graph")
 	graphCmd.AddCommand(graphRunCmd)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -83,6 +83,12 @@ func CheckFileExists(filePath string) bool {
 	return true
 }
 
+// EnsureDirectory creates a directory if it doesn't exist
+// Returns an error if the directory cannot be created
+func EnsureDirectory(dirPath string) error {
+	return os.MkdirAll(dirPath, 0755)
+}
+
 func ParseFlags(scenarioDetail *models.ScenarioDetail, args []string, scenarioCollectedFlags map[string]*string, skipDefault bool) (env *map[string]ParsedField, vol *map[string]string, err error) {
 	environment := make(map[string]ParsedField)
 	volumes := make(map[string]string)

--- a/pkg/scenarioorchestrator/docker/scenario_orchestrator.go
+++ b/pkg/scenarioorchestrator/docker/scenario_orchestrator.go
@@ -466,8 +466,9 @@ func (c *ScenarioOrchestrator) RunGraph(
 	commChannel chan *orchestratormodels.GraphCommChannel,
 	registry *providermodels.RegistryV2,
 	userID *int,
+	outputDir *string,
 ) {
-	scenarioorchestrator.CommonRunGraph(scenarios, resolvedGraph, extraEnv, extraVolumeMounts, cache, commChannel, c, c.Config, registry, userID)
+	scenarioorchestrator.CommonRunGraph(scenarios, resolvedGraph, extraEnv, extraVolumeMounts, cache, commChannel, c, c.Config, registry, userID, outputDir)
 }
 
 func (c *ScenarioOrchestrator) PrintContainerRuntime() {

--- a/pkg/scenarioorchestrator/podman/scenario_orchestrator.go
+++ b/pkg/scenarioorchestrator/podman/scenario_orchestrator.go
@@ -373,9 +373,10 @@ func (c *ScenarioOrchestrator) RunGraph(
 	commChannel chan *orchestratormodels.GraphCommChannel,
 	registry *providermodels.RegistryV2,
 	userID *int,
+	outputDir *string,
 ) {
 	//TODO: add a getconfig method in scenarioOrchestrator
-	scenarioorchestrator.CommonRunGraph(scenarios, resolvedGraph, extraEnv, extraVolumeMounts, cache, commChannel, c, c.Config, registry, userID)
+	scenarioorchestrator.CommonRunGraph(scenarios, resolvedGraph, extraEnv, extraVolumeMounts, cache, commChannel, c, c.Config, registry, userID, outputDir)
 }
 
 func (c *ScenarioOrchestrator) PrintContainerRuntime() {

--- a/pkg/scenarioorchestrator/scenario_orchestrator.go
+++ b/pkg/scenarioorchestrator/scenario_orchestrator.go
@@ -46,6 +46,7 @@ type ScenarioOrchestrator interface {
 		commChannel chan *orchestrator_models.GraphCommChannel,
 		registry *models.RegistryV2,
 		userID *int,
+		outputDir *string,
 	)
 
 	CleanContainers(ctx context.Context) (*int, error)

--- a/pkg/scenarioorchestrator/scenarioorchestratortest/common_test_functions.go
+++ b/pkg/scenarioorchestrator/scenarioorchestratortest/common_test_functions.go
@@ -330,7 +330,7 @@ func CommonTestScenarioOrchestratorRunGraph(t *testing.T, so scenarioorchestrato
 
 	commChannel := make(chan *models.GraphCommChannel)
 	go func() {
-		so.RunGraph(nodes, executionPlan, map[string]string{}, map[string]string{}, false, commChannel, nil, uid)
+		so.RunGraph(nodes, executionPlan, map[string]string{}, map[string]string{}, false, commChannel, nil, uid, nil)
 	}()
 
 	for {
@@ -406,7 +406,7 @@ func CommonTestScenarioOrchestratorRunGraph(t *testing.T, so scenarioorchestrato
 
 	commChannel = make(chan *models.GraphCommChannel)
 	go func() {
-		so.RunGraph(nodes, executionPlan, map[string]string{}, map[string]string{}, false, commChannel, nil, uid)
+		so.RunGraph(nodes, executionPlan, map[string]string{}, map[string]string{}, false, commChannel, nil, uid, nil)
 	}()
 
 	for {


### PR DESCRIPTION

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  
Close https://github.com/krkn-chaos/krknctl/issues/68
we can have a flag like --output or -o to control the output path for log files.And the kubeconfig files will be deleted in the end
<img width="490" height="162" alt="image" src="https://github.com/user-attachments/assets/33ea1e23-a3ad-410f-83bd-c8baaa27f9a9" />


## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  