### PR TITLE
fix: remove panic in IsFile() on file close error

### DIFF
--- a/pkg/typing/types.go
+++ b/pkg/typing/types.go
@@ -88,11 +88,8 @@ func IsFile(f string) bool {
 	file, err := os.Open(f)
 
 	defer func() {
-		if err == nil && file != nil {
-			deferErr := file.Close()
-			if deferErr != nil {
-				panic(deferErr)
-			}
+		if file != nil {
+			_ = file.Close()
 		}
 	}()
 


### PR DESCRIPTION
### **User description**
## Description

Fixes #93

The IsFile() function in pkg/typing/types.go uses `panic()` to handle file close errors. This can crash the application when running on network filesystems or container volumes where I/O errors may occur during `file.Close()`.

For read-only file handles, close errors can be safely ignored. This PR removes the panic and silently discards the close error.

**Before:**
```go
defer func() {
    if err == nil && file != nil {
        deferErr := file.Close()
        if deferErr != nil {
            panic(deferErr)
        }
    }
}()

```
After :
```go
defer func() {
    if file != nil {
        _ = file.Close()
    }
}()
```


___

### **PR Type**
Bug fix


___

### **Description**
- Remove panic on file close error in IsFile() function

- Safely ignore close errors for read-only file handles

- Prevent application crashes on network filesystems


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IsFile() function"] --> B["Open file"]
  B --> C["Defer cleanup"]
  C --> D["Old: panic on close error"]
  C --> E["New: silently ignore close error"]
  D --> F["Application crash risk"]
  E --> G["Graceful error handling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Remove panic on file close error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/typing/types.go

<ul><li>Removed panic statement from file close error handling in IsFile()<br> <li> Simplified defer cleanup logic to safely ignore close errors<br> <li> Changed from conditional error checking to unconditional file close<br> <li> Prevents application crashes on network filesystems or container <br>volumes</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/94/files#diff-bd41f6fa9e1132a2b1d9409d5288988fc5fd8c02dea21e70ec36c96518ea8bd1">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

