### PR TITLE
fix: secure kubeconfig file permissions (0644 to 0600)

### DIFF
--- a/pkg/scenarioorchestrator/utils/utils.go
+++ b/pkg/scenarioorchestrator/utils/utils.go
@@ -105,7 +105,7 @@ func PrepareKubeconfig(kubeconfigPath *string, config config.Config) (*string, e
 	}
 	filename := fmt.Sprintf("%s-%s-%d", config.KubeconfigPrefix, text.RandString(5), time.Now().Unix())
 	path := filepath.Join(currentDirectory, filename)
-	err = os.WriteFile(path, flattenedConfig, 0644) /* #nosec */
+	err = os.WriteFile(path, flattenedConfig, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### **User description**
## Description

Fixes #95

Kubeconfig files contain sensitive credentials (client certificates, private keys, auth tokens). They were being written with `0644` permissions, making them world-readable.

Changed to `0600` (owner read/write only) to match `kubectl` default behavior.

**Before:**
```go
err = os.WriteFile(path, flattenedConfig, 0644) /* #nosec */
```

**After:**
```go
err = os.WriteFile(path, flattenedConfig, 0600)
```

## Documentation

- [ ] **Is documentation needed for this update?**

No - this is a security fix with no user-facing changes.

## Related Documentation PR (if applicable)

N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Secure kubeconfig file permissions from world-readable to owner-only

- Change file mode from 0644 to 0600 in WriteFile call

- Remove unnecessary nosec comment after permission fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kubeconfig WriteFile"] -->|"Change permissions"| B["0644 world-readable"]
  A -->|"Fix to"| C["0600 owner-only"]
  B -->|"Security Risk"| D["Sensitive credentials exposed"]
  C -->|"Secure"| E["Matches kubectl defaults"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Secure kubeconfig file permissions to owner-only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/scenarioorchestrator/utils/utils.go

<ul><li>Changed <code>os.WriteFile</code> file permission mode from <code>0644</code> to <code>0600</code><br> <li> Removed <code>/* #nosec */</code> comment that was suppressing security warnings<br> <li> Ensures kubeconfig files containing sensitive credentials are <br>owner-readable only</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/96/files#diff-8b50b28b64cc963048b354305ee547de2d955ea77d78537fd230d74db66f5154">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

