### PR TITLE
fix: add nil check for Password in ToDockerV2AuthString

### DIFF
--- a/pkg/provider/models/models.go
+++ b/pkg/provider/models/models.go
@@ -105,7 +105,7 @@ func (r *RegistryV2) ToDockerV2AuthString() (*string, error) {
 	if r.Token != nil {
 		authConfig.RegistryToken = *r.Token
 	} else {
-		if r.Username != nil {
+		if r.Username != nil && r.Password != nil {
 			authConfig.Username = *r.Username
 			authConfig.Password = *r.Password
 		} else {


### PR DESCRIPTION
### **User description**
## Description

Fixes #97 

In `ToDockerV2AuthString()`, the code checks if `Username` is not nil before dereferencing it, but doesn't check `Password`. This causes a nil pointer panic if username is provided without a password.

**Before:**
```go
if r.Username != nil {
    authConfig.Username = *r.Username
    authConfig.Password = *r.Password  // panic if Password is nil
}
```

**After:**
```go
if r.Username != nil && r.Password != nil {
    authConfig.Username = *r.Username
    authConfig.Password = *r.Password
}
```

## Documentation

- [ ] **Is documentation needed for this update?**

No - this is a bug fix with no user-facing changes.

## Related Documentation PR (if applicable)

N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Add nil check for `Password` before dereferencing in `ToDockerV2AuthString()`

- Prevents nil pointer panic when username provided without password


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ToDockerV2AuthString method"] -->|checks Username and Password| B["Both not nil"]
  A -->|Username nil or Password nil| C["Return nil, nil"]
  B -->|dereference safely| D["Set authConfig values"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.go</strong><dd><code>Add Password nil check in auth string conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/provider/models/models.go

<ul><li>Added nil check for <code>r.Password</code> alongside existing <code>r.Username</code> check<br> <li> Prevents panic when dereferencing Password pointer in else branch<br> <li> Maintains existing logic flow with improved safety</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/98/files#diff-68cd8f9d185ef273864c8bda466e7e90156d28942feb5e9e5dda429261bb43a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

