### PR TITLE
fix: remove duplicate error checks

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -28,10 +28,6 @@ func NewDescribeCommand(factory *factory.ProviderFactory, config config.Config) 
 					return []string{}, cobra.ShellCompDirectiveError
 				}
 			}
-			if err != nil {
-				log.Fatalf("Error fetching scenarios: %v", err)
-				return []string{}, cobra.ShellCompDirectiveError
-			}
 			privateRegistry := false
 			if registrySettings != nil {
 				privateRegistry = true
@@ -64,10 +60,6 @@ func NewDescribeCommand(factory *factory.ProviderFactory, config config.Config) 
 			spinner := NewSpinnerWithSuffix("fetching scenario details...")
 			spinner.Start()
 
-			if err != nil {
-				spinner.Stop()
-				return err
-			}
 			provider := GetProvider(registrySettings != nil, factory)
 			scenarioDetail, err := provider.GetScenarioDetail(args[0], registrySettings)
 			if err != nil {

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -103,10 +103,6 @@ func NewGraphRunCommand(factory *providerfactory.ProviderFactory, scenarioOrches
 				return err
 			}
 
-			if err != nil {
-				return err
-			}
-
 			kubeconfigPath, err := utils.PrepareKubeconfig(&kubeconfig, config)
 			if err != nil {
 				return err

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,9 +45,6 @@ func NewListScenariosCommand(factory *providerfactory.ProviderFactory, config co
 				logPrivateRegistry(registrySettings.RegistryURL)
 			}
 
-			if err != nil {
-				return err
-			}
 			privateRegistry := false
 			if registrySettings != nil {
 				privateRegistry = true

--- a/cmd/random.go
+++ b/cmd/random.go
@@ -294,9 +294,6 @@ func NewRandomScaffoldCommand(factory *providerfactory.ProviderFactory, config c
 					return err
 				}
 			}
-			if err != nil {
-				return err
-			}
 			dataProvider := GetProvider(registrySettings != nil, factory)
 			includeGlobalEnv, err := cmd.Flags().GetBool("global-env")
 			if err != nil {
@@ -327,10 +324,6 @@ func NewRandomScaffoldCommand(factory *providerfactory.ProviderFactory, config c
 				if len(args) == 0 {
 					return fmt.Errorf("please provide at least one scenario")
 				}
-			}
-
-			if err != nil {
-				return err
 			}
 
 			output, err := dataProvider.ScaffoldScenarios(args, includeGlobalEnv, registrySettings, true, seed)


### PR DESCRIPTION
### **User description**
## Description

Fixes #99

Removes duplicate error checks in `cmd/graph.go` and `cmd/random.go`. After the first `if err != nil { return err }`, the error is guaranteed to be nil, making the second check dead code.

**Example (removed):**
```go
if err != nil {
    return err
}
if err != nil {  // dead code - err is nil here
    return err
}
```

## Documentation

- [ ] **Is documentation needed for this update?**

No - this is a code cleanup with no functional changes.

## Related Documentation PR (if applicable)

N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate dead code error checks in cmd/graph.go

- Remove duplicate dead code error checks in cmd/random.go

- Error variable guaranteed nil after first check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cmd/graph.go<br/>cmd/random.go"] -- "Remove dead code<br/>duplicate err checks" --> B["Cleaner code<br/>no functional change"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph.go</strong><dd><code>Remove duplicate error check after flag retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/graph.go

<ul><li>Removed duplicate <code>if err != nil { return err }</code> check after <code>exitOnerror</code> <br>flag retrieval<br> <li> Error variable is guaranteed to be nil after first check, making <br>second check dead code<br> <li> No functional changes to command behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/100/files#diff-171d9186355919e81f4548c3a10b7500b2702557a9ac818bf2cd820124358d89">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>random.go</strong><dd><code>Remove two duplicate error checks in scaffold command</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/random.go

<ul><li>Removed duplicate <code>if err != nil { return err }</code> check after <br><code>parsePrivateRepoArgs</code> call<br> <li> Removed duplicate <code>if err != nil { return err }</code> check after scenario <br>argument validation<br> <li> Both checks were dead code following earlier error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/100/files#diff-734adb146031b7bb6b795819a73053540b71647a78ea6da8d60224090e7bcf9d">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

