### PR TITLE
fix: close log files in CommonRunGraph to prevent resource leak

### DIFF
--- a/pkg/scenarioorchestrator/common_functions.go
+++ b/pkg/scenarioorchestrator/common_functions.go
@@ -76,6 +76,7 @@ func CommonRunGraph(
 			wg.Add(1)
 
 			go func() {
+				defer file.Close()
 				defer wg.Done()
 				_, err = orchestrator.RunAttached(scenario.Image, containerName, env, cache, volumes, file, file, nil, ctx, registry)
 				if err != nil {


### PR DESCRIPTION
### **User description**
## Description

Fixes #101

Log files created in `CommonRunGraph()` were never closed, causing a resource leak. Each scenario run leaked a file descriptor, which could lead to hitting OS limits during long-running graph executions.

Added `defer file.Close()` in the goroutine to ensure proper cleanup.

**Before:**
```go
go func() {
    defer wg.Done()
    _, err = orchestrator.RunAttached(..., file, file, ...)
}()
```

**After:**
```go
go func() {
    defer file.Close()
    defer wg.Done()
    _, err = orchestrator.RunAttached(..., file, file, ...)
}()
```

## Documentation

- [ ] **Is documentation needed for this update?**

No - this is a bug fix with no user-facing changes.

## Related Documentation PR (if applicable)

N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Close log files in CommonRunGraph goroutine to prevent resource leak

- Added defer statement to ensure file cleanup after orchestrator execution

- Prevents file descriptor exhaustion during long-running graph executions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Log file created"] --> B["Goroutine spawned"]
  B --> C["defer file.Close added"]
  C --> D["File properly cleaned up"]
  D --> E["Resource leak prevented"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_functions.go</strong><dd><code>Add file close defer in goroutine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/scenarioorchestrator/common_functions.go

<ul><li>Added <code>defer file.Close()</code> statement in goroutine to ensure log file <br>cleanup<br> <li> Placed before <code>defer wg.Done()</code> to guarantee file closure before <br>goroutine exit<br> <li> Fixes resource leak where file descriptors were never released</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/102/files#diff-fc718971088aefcabeb4f8855e1a7c584a6b863780b38d15d3b6dafd43f5da87">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

