### PR TITLE
fix: prevent stack overflow in InputField.Validate (#25)

### DIFF
--- a/pkg/typing/field.go
+++ b/pkg/typing/field.go
@@ -103,6 +103,10 @@ func (f *InputField) UnmarshalJSON(data []byte) error {
 }
 
 func (f *InputField) Validate(value *string) (*string, error) {
+	return f.validate(value, true)
+}
+
+func (f *InputField) validate(value *string, validateDefault bool) (*string, error) {
 	var deferErr error
 	// if string value is nil, the default value is nil and the field is required the field is not valid
 	if value == nil && f.Default == nil && f.Required && f.Type == String {
@@ -124,9 +128,11 @@ func (f *InputField) Validate(value *string) (*string, error) {
 		// recursive call to validate default value
 		// to avoid schema development errors
 
-		// the default value is validated recursively
-		if _, err := f.Validate(selectedValue); err != nil {
-			return nil, errors.New("schema validation error on default value: " + err.Error())
+		// the default value is validated recursively (only once to prevent stack overflow)
+		if validateDefault {
+			if _, err := f.validate(selectedValue, false); err != nil {
+				return nil, errors.New("schema validation error on default value: " + err.Error())
+			}
 		}
 	} else {
 		selectedValue = value


### PR DESCRIPTION
### **User description**
## Description  
Fixes #25 - Stack overflow on node scenarios.

Added internal `validate(value, validateDefault)` helper with a boolean flag to prevent infinite recursion when validating default values for non-String types.

## Documentation  
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent stack overflow in InputField validation logic

- Add internal validate helper with recursion control flag

- Validate default values only once to avoid infinite loops


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InputField.Validate"] -->|calls with flag true| B["validate helper"]
  B -->|validates default value| C["validate helper"]
  C -->|flag false prevents| D["recursive validation"]
  D -->|avoids| E["stack overflow"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field.go</strong><dd><code>Add recursion control to prevent stack overflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/typing/field.go

<ul><li>Refactored <code>Validate</code> method to delegate to internal <code>validate</code> helper <br>function<br> <li> Added <code>validateDefault</code> boolean parameter to control recursion depth<br> <li> Modified default value validation to call <code>validate</code> with <br><code>validateDefault=false</code> to prevent infinite recursion<br> <li> Updated comment to clarify recursion prevention mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krknctl/pull/106/files#diff-fcc6f1975929f4fa02b80d1635daca4b7cb5015b5b066bf1b78acf7b4db43367">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

