### PR TITLE
Fix nil pointer dereference in scaffold --global-env

### DIFF
--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -145,8 +145,9 @@ func scaffoldScenarios(scenarios []string, includeGlobalEnv bool, registry *mode
 			}
 
 			for _, field := range globalDetail.Fields {
-				scenarioNode.Env[*field.Variable] = *field.Default
-
+				if field.Variable != nil && field.Default != nil {
+					scenarioNode.Env[*field.Variable] = *field.Default
+				}
 			}
 		}
 		scenarioNodes[indexes[i]] = scenarioNode


### PR DESCRIPTION
Fixes #137

## Problem

`krknctl graph scaffold <scenario> --global-env` panics with a misleading "impossible to locate american words dictionary" error when any global environment field has no `"default"` value.

### Reproduction

```bash
krknctl graph scaffold node-cpu-hog --global-env
```

No cluster, credentials, or env vars needed.

## Root Cause Investigation

### What actually broke

On **March 20**, krkn release [`v5.0.2`](https://github.com/krkn-chaos/krkn/releases/tag/v5.0.2) included commit [`62dadfe`](https://github.com/krkn-chaos/krkn/commit/62dadfe2) ("Resiliency Score krknctl compatibility fixes"), which added three global environment fields to `containers/krknctl-input.json` **without `"default"` values**:

```json
{ "name": "resiliency-score", "variable": "RESILIENCY_SCORE", "type": "boolean" }
{ "name": "disable-resiliency-score", "variable": "DISABLE_RESILIENCY_SCORE", "type": "boolean" }
{ "name": "resiliency-file", "variable": "RESILIENCY_FILE", "type": "file" }
```

Since `Default` is a `*string` with `omitempty`, these fields deserialize to `nil`. When `scaffoldScenarios` iterated global env fields and unconditionally dereferenced `*field.Default`, it panicked.

### Why the error message was misleading

The `recover()` handler in `ScaffoldScenarios` had two bugs:

1. **Catch-all scope** — it wrapped the entire function, catching ALL panics (not just babble/dictionary ones) and always printing "impossible to locate american words dictionary"
2. **Variable shadowing** — `if err := recover()` shadowed the function's return `err`, so the function silently returned `(nil, nil)` instead of propagating the error

### How the image reached krknctl

1. `v5.0.2` tag push triggered Docker Image CI in `krkn-chaos/krkn`
2. Pushed `quay.io/krkn-chaos/krkn:latest` with the new global env labels
3. Workflow's "Rebuild krkn-hub" step rebuilt all `krkn-hub` images (`FROM quay.io/krkn-chaos/krkn:latest`)
4. krknctl test fetches live manifests from `quay.io/krkn-chaos/krkn-hub` — so the nil `Default` fields immediately affected CI

### Timeline

| Date | Event |
|------|-------|
| Mar 16 | Last passing CI — global env fields all had `"default"` values |
| Mar 20 | krkn `v5.0.2` released — 3 fields added without defaults |
| Mar 20 | krkn-hub images rebuilt with new base image |
| Apr 3 | First krknctl CI failure — nil deref masked as dictionary error |

### Evidence

- The same failure reproduces on unrelated PRs: [#135 (dependabot)](https://github.com/krkn-chaos/krknctl/actions/runs/24426271749)
- Only the 4th `ScaffoldScenarios` call fails (the one with `includeGlobalEnv=true`) — the first 3 calls succeed, proving the dictionary was never the issue
- Local reproduction confirms panic at `common.go:155`: `scenarioNode.Env[*field.Variable] = *field.Default`

## Fix

| Commit | Change |
|--------|--------|
| 1 | Added `/usr/share/dict/words` symlink in CI workflow (defensive — prevents future dictionary issues on Ubuntu 24.04 runners) |
| 2 | Added nil check for `globalDetail` before iterating `.Fields` |
| 3 | Extracted babble init into `newBabbler()` with scoped recover; removed the catch-all recover from `ScaffoldScenarios` so panics propagate with real stack traces |
| 4 | Added nil checks for `field.Variable` and `field.Default` before dereferencing — the actual crash fix |

## Documentation
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)