### PR TITLE
fix: race condition in Attach function for both Docker and Podman orchestrators

### DIFF
--- a/pkg/scenarioorchestrator/docker/scenario_orchestrator.go
+++ b/pkg/scenarioorchestrator/docker/scenario_orchestrator.go
@@ -111,6 +111,7 @@ func (c *ScenarioOrchestrator) Attach(containerID *string, signalChannel chan os
 	}()
 	errorChan := make(chan error)
 	finishChan := make(chan error)
+	copyDoneChan := make(chan struct{})
 
 	// copies demultiplexed reader to Stdout and Stderr
 	go func() {
@@ -118,6 +119,7 @@ func (c *ScenarioOrchestrator) Attach(containerID *string, signalChannel chan os
 		if err != nil {
 			errorChan <- err
 		}
+		close(copyDoneChan)
 	}()
 
 	// waits for:
@@ -130,6 +132,8 @@ func (c *ScenarioOrchestrator) Attach(containerID *string, signalChannel chan os
 		case err := <-errCH:
 			errorChan <- err
 		case <-respCh:
+			// Wait for StdCopy to finish before signaling completion
+			<-copyDoneChan
 			finishChan <- nil
 		}
 	}()

--- a/pkg/scenarioorchestrator/docker/scenario_orchestrator_test.go
+++ b/pkg/scenarioorchestrator/docker/scenario_orchestrator_test.go
@@ -150,3 +150,17 @@ func TestScenarioOrchestrator_Docker_ResolveContainerId(t *testing.T) {
 	sodocker := ScenarioOrchestrator{Config: config, ContainerRuntime: models.Docker}
 	scenarioorchestratortest.CommonTestScenarioOrchestratorResolveContainerName(t, &sodocker, config, 3)
 }
+
+func TestScenarioOrchestrator_Docker_AttachRaceCondition(t *testing.T) {
+	config := scenarioorchestratortest.CommonGetTestConfig(t)
+	sodocker := ScenarioOrchestrator{Config: config, ContainerRuntime: models.Docker}
+	
+	// Run the test multiple times to increase chance of catching race condition
+	for i := 0; i < 5; i++ {
+		fileContent := scenarioorchestratortest.CommonAttachWait(t, &sodocker, config)
+		
+		// Verify that the expected output is present... this ensures logs weren't truncated
+		assert.True(t, strings.Contains(fileContent, "Release the krkn 4"), 
+			"Expected log output not found in iteration %d, logs may have been truncated due to race condition", i)
+	}
+}

--- a/pkg/scenarioorchestrator/podman/scenario_orchestrator.go
+++ b/pkg/scenarioorchestrator/podman/scenario_orchestrator.go
@@ -145,6 +145,7 @@ func (c *ScenarioOrchestrator) Attach(containerID *string, signalChannel chan os
 
 	errorChannel := make(chan error, 1)
 	finishChannel := make(chan bool, 1)
+	attachDoneChan := make(chan struct{})
 	var mu sync.Mutex
 	go func() {
 		mu.Lock()
@@ -153,6 +154,12 @@ func (c *ScenarioOrchestrator) Attach(containerID *string, signalChannel chan os
 		if err != nil {
 			errorChannel <- err
 		}
+		close(attachDoneChan)
+	}()
+
+	go func() {
+		// Wait for attach to complete before signaling finish
+		<-attachDoneChan
 		finishChannel <- true
 	}()
 

--- a/pkg/scenarioorchestrator/podman/scenario_orchestrator_test.go
+++ b/pkg/scenarioorchestrator/podman/scenario_orchestrator_test.go
@@ -160,3 +160,17 @@ func TestScenarioOrchestrator_Podman_ResolveContainerId(t *testing.T) {
 	sopodman := ScenarioOrchestrator{Config: config, ContainerRuntime: models.Podman}
 	scenarioorchestratortest.CommonTestScenarioOrchestratorResolveContainerName(t, &sopodman, config, 3)
 }
+
+func TestScenarioOrchestrator_Podman_AttachRaceCondition(t *testing.T) {
+	config := scenarioorchestratortest.CommonGetTestConfig(t)
+	sopodman := ScenarioOrchestrator{Config: config, ContainerRuntime: models.Podman}
+	
+	// Run the test multiple times to increase chance of catching race condition
+	for i := 0; i < 5; i++ {
+		fileContent := scenarioorchestratortest.CommonAttachWait(t, &sopodman, config)
+		
+		// Verify that the expected output is present... this ensures logs weren't truncated
+		assert.True(t, strings.Contains(fileContent, "Release the krkn 4"), 
+			"Expected log output not found in iteration %d, logs may have been truncated due to race condition", i)
+	}
+}


### PR DESCRIPTION
## Description  

The Attach function had a race condition where ContainerWait could signal completion before StdCopy/Attach finished copying all logs... leading to truncated log output. This was happening because the log copying goroutine didn't signal when it was done.

Changes:
- Docker: Added copyDoneChan that closes when StdCopy completes. ContainerWait now waits for this channel before signaling finish.
- Podman: Added attachDoneChan that closes when containers.Attach completes. The finish signal now waits for attach to complete.
- Added tests for both orchestrators that run the attach operation multiple times to verify logs are fully captured and not truncated."