### PR TITLE
Show source scenario docs when assist maps to a runnable krknctl scenario

### DIFF
--- a/pkg/assist/assist.go
+++ b/pkg/assist/assist.go
@@ -87,7 +87,9 @@ func DeployAssistModel(ctx context.Context, orchestrator scenarioorchestrator.Sc
 	// Run the RAG container in detached mode
 	containerID, err := orchestrator.Run(ragImageURI, containerName, env, true, nil, &devices,
 		&commChan, ctx, registry, portMappings)
-	pullSpinner.Stop()
+	if pullSpinner != nil {
+		pullSpinner.Stop()
+	}
 
 	// The orchestrator closes the channel automatically, so we don't need to close it manually
 	if err != nil {

--- a/pkg/assist/assist.go
+++ b/pkg/assist/assist.go
@@ -246,7 +246,15 @@ func StartInteractivePrompt(containerID string, hostPort string, orchestrator sc
 
 		// If a scenario was detected, show scenario details
 		if response.ScenarioName != nil && *response.ScenarioName != "" {
-			fmt.Printf("\n📋 fetching details for scenario: %s\n", *response.ScenarioName)
+			var matchedScenario *ScenarioMatch
+			if len(response.Scenarios) > 0 {
+				matchedScenario = &response.Scenarios[0]
+			}
+			if matchedScenario != nil && matchedScenario.Name != "" && matchedScenario.Name != *response.ScenarioName {
+				printAssistScenarioDocumentation(*matchedScenario)
+			}
+
+			fmt.Printf("\n📋 fetching runnable details for scenario: %s\n", *response.ScenarioName)
 
 			scenarioDetail, err := scenarioProvider.GetScenarioDetail(*response.ScenarioName, nil)
 			if err != nil {
@@ -320,6 +328,29 @@ func StartInteractivePrompt(containerID string, hostPort string, orchestrator sc
 	}
 
 	return nil
+}
+
+// printAssistScenarioDocumentation shows source documentation from the assist index when
+// it differs from the runnable krkn-hub scenario tag used for forms and execution.
+func printAssistScenarioDocumentation(match ScenarioMatch) {
+	title := match.Title
+	if title == "" {
+		title = match.Name
+	}
+	if title == "" && match.Summary == "" && match.RunCommand == "" {
+		return
+	}
+
+	fmt.Print("\n")
+	_, _ = color.New(color.FgGreen, color.Underline).Println(title)
+	if match.Summary != "" {
+		for _, line := range text.Justify(match.Summary, 65) {
+			fmt.Println(line)
+		}
+	}
+	if match.RunCommand != "" {
+		fmt.Printf("\nCommand: %s\n", match.RunCommand)
+	}
 }
 
 // queryAssistService sends a query to the assist service and returns the response

--- a/pkg/assist/models.go
+++ b/pkg/assist/models.go
@@ -53,5 +53,18 @@ type QueryResponse struct {
 		CompletionTokens int `json:"completion_tokens"`
 		TotalTokens      int `json:"total_tokens"`
 	} `json:"usage"`
-	ScenarioName *string `json:"scenario_name,omitempty"` // krknctl scenario name if detected
+	ScenarioName *string         `json:"scenario_name,omitempty"` // krknctl scenario name if detected
+	Scenarios    []ScenarioMatch `json:"scenarios,omitempty"`
+}
+
+// ScenarioMatch represents a scenario matched by the assist service.
+type ScenarioMatch struct {
+	Name         string  `json:"name,omitempty"`
+	RunnableName string  `json:"runnable_name,omitempty"`
+	Title        string  `json:"title,omitempty"`
+	Summary      string  `json:"summary,omitempty"`
+	RunCommand   string  `json:"run_command,omitempty"`
+	Score        float64 `json:"score,omitempty"`
+	Rank         int     `json:"rank,omitempty"`
+	IsPrimary    bool    `json:"is_primary,omitempty"`
 }

--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -145,7 +145,11 @@ func scaffoldScenarios(scenarios []string, includeGlobalEnv bool, registry *mode
 			}
 
 			for _, field := range globalDetail.Fields {
-				scenarioNode.Env[*field.Variable] = *field.Default
+				if field.Default != nil {
+					scenarioNode.Env[*field.Variable] = *field.Default
+				} else {
+					scenarioNode.Env[*field.Variable] = ""
+				}
 
 			}
 		}

--- a/pkg/provider/models/models.go
+++ b/pkg/provider/models/models.go
@@ -113,7 +113,7 @@ func (r *RegistryV2) ToDockerV2AuthString() (*string, error) {
 		}
 	}
 
-	encodedJSON, err := json.Marshal(authConfig)
+	encodedJSON, err := json.Marshal(authConfig) // #nosec G117 -- not a hardcoded credential, holds runtime user input
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
This PR improves `krknctl assist` for scenarios whose source documentation lives under one scenario id, but whose runnable `krknctl` command belongs to another downstream scenario.

Today, when assist maps a niche scenario page to a different runnable scenario, `krknctl` only shows the runnable scenario details. That means users lose the original source context that actually matched their query.

This change makes `krknctl assist` preserve and display that source scenario context when it is available, while keeping execution behavior unchanged.

For mapped scenarios, the CLI now:
- reads the richer scenario match payload returned by assist
- displays the matched source scenario title, summary, and suggested command
- still fetches runnable details, forms, and execution parameters using the runnable scenario id

This is especially useful for website scenarios that are documented as source pages without a direct `krkn-hub-scenario` id, but are implemented through another runnable `krknctl` scenario. In those cases, users now see both:
- the source scenario context they asked about
- the runnable scenario details needed to execute it

Examples of effective changes due to this PR:
- aurora-disruption now shows the Aurora-specific description and suggested command, then continues to the runnable `pod-network-filter` fields.
- efs-disruption now shows the EFS-specific description first, then continues to the runnable `node-network-filter` fields.

## Documentation
- [ ] Is documentation needed for this update?

This is a CLI presentation/update-path change only. No documentation update is required because the source scenario documentation already exists in the website repo, and this PR only changes how `krknctl` presents assist results.

## Related Documentation PR (if applicable)
N/A