### PR TITLE
Add centos9-compatible linux/amd64 release artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,9 +138,52 @@ jobs:
         name: darwin-intel
         path: krknctl-${{github.event.release.tag_name}}-darwin-intel.tar.gz
 
+  # Builds a separate linux/amd64 binary inside a CentOS Stream 9 container so
+  # the CGO dynamic link is stamped against GLIBC 2.34 (the RHEL 9 / CentOS 9
+  # system version) rather than the GLIBC 2.38+ that ubuntu-latest (24.04)
+  # would embed.  Consumers on CentOS/RHEL 9 Jenkins agents must use this
+  # artifact instead of the standard linux-amd64 build.
+  build-linux-amd64-centos9:
+    name: Build linux/amd64 (CentOS Stream 9)
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+    permissions:
+      contents: write
+    steps:
+    - name: install build dependencies
+      run: dnf install -y git curl tar btrfs-progs-devel gcc jq
+
+    - uses: actions/checkout@v4
+
+    - name: install go
+      run: |
+        curl -fsSL https://go.dev/dl/go1.26.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+        echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+
+    - name: advance version
+      run: |
+        cat <<< $(jq '.version="${{github.event.release.tag_name}}"' pkg/config/config.json) > pkg/config/config.json
+
+    - name: build linux amd64 centos9
+      env:
+        GOOS: linux
+        GOARCH: amd64
+        CGO_ENABLED: 1
+        BINARY: linux-amd64-centos9
+      run: |
+        go build -mod=vendor -tags containers_image_openpgp -ldflags="-w -s" -o $BINARY/ ./...
+        tar cfvz krknctl-${{github.event.release.tag_name}}-$BINARY.tar.gz -C $BINARY krknctl
+
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-amd64-centos9
+        path: krknctl-${{github.event.release.tag_name}}-linux-amd64-centos9.tar.gz
+
   upload-releases:
     name: Upload release artifacts
-    needs: [build-linux-amd64, build-linux-arm64, build-darwin]
+    needs: [build-linux-amd64, build-linux-arm64, build-darwin, build-linux-amd64-centos9]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Description  
The existing linux-amd64 build runs on ubuntu-latest (Ubuntu 24.04, GLIBC 2.39) with CGO_ENABLED=1, which stamps a GLIBC_2.38 minimum requirement into the binary. CentOS Stream 9 / RHEL 9 ships GLIBC 2.34 and will not receive glibc updates, so the standard binary fails there.

Add a new build-linux-amd64-centos9 job that runs inside a quay.io/centos/centos:stream9 container. Because the CGO dynamic link resolves against GLIBC 2.34 in that environment, the resulting binary works on any RHEL/CentOS 9 Jenkins agent or similar host.

The artifact is published to the same release as
krknctl-<tag>-linux-amd64-centos9.tar.gz and is included in the checksums file.


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  

https://redhat.atlassian.net/browse/CHAOS-1813