### PR TITLE
Group typing

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -85,8 +85,7 @@ func PrintScenarioDetail(scenarioDetail *models.ScenarioDetail) {
 		fmt.Println(line)
 	}
 	fmt.Print("\n")
-	argumentTable := NewArgumentTable(scenarioDetail.Fields)
-	argumentTable.Print()
+	PrintGroupedArgumentTables(scenarioDetail.Fields)
 	fmt.Print("\n")
 
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -113,17 +114,6 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 
 			cmd.LocalFlags().AddFlagSet(globalFlags)
 			cmd.LocalFlags().AddFlagSet(scenarioFlags)
-
-			cmd.SetHelpFunc(func(command *cobra.Command, args []string) {
-				yellow := color.New(color.FgYellow).SprintFunc()
-				green := color.New(color.FgGreen).SprintFunc()
-				boldGreen := color.New(color.FgHiGreen, color.Bold).SprintFunc()
-				fmt.Printf("%s", yellow("Krkn Global flags\n"))
-				printHelp(*globalEnvDetail)
-				fmt.Printf("\n%s %s\n", boldGreen(scenarioDetail.Name), green("Flags"))
-				printHelp(*scenarioDetail)
-				fmt.Print("\n\n")
-			})
 
 			return nil
 		},
@@ -449,24 +439,126 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 		},
 	}
 
+	command.SetHelpFunc(func(cmd *cobra.Command, _ []string) {
+		yellow := color.New(color.FgYellow).SprintFunc()
+		green := color.New(color.FgGreen).SprintFunc()
+		boldGreen := color.New(color.FgHiGreen, color.Bold).SprintFunc()
+
+		// cobra always passes an empty slice to help functions, so read os.Args directly
+		// to find the first positional arg after "run" — that's the scenario name
+		var scenarioName string
+		for i, arg := range os.Args {
+			if arg == "run" && i+1 < len(os.Args) {
+				for _, next := range os.Args[i+1:] {
+					if !strings.HasPrefix(next, "-") {
+						scenarioName = next
+						break
+					}
+				}
+				break
+			}
+		}
+
+		if scenarioName == "" {
+			_ = cmd.Usage()
+			return
+		}
+
+		registrySettings, _ := models.NewRegistryV2FromEnv(config)
+		provider := GetProvider(registrySettings != nil, factory)
+
+		globalEnvDetail, err := provider.GetGlobalEnvironment(registrySettings, scenarioName)
+		if err != nil || globalEnvDetail == nil {
+			_ = cmd.Usage()
+			return
+		}
+		scenarioDetail, err := provider.GetScenarioDetail(scenarioName, registrySettings)
+		if err != nil || scenarioDetail == nil {
+			_ = cmd.Usage()
+			return
+		}
+
+		fmt.Printf("%s", yellow("Krkn Global flags\n"))
+		printHelp(*globalEnvDetail)
+		fmt.Printf("\n%s %s\n", boldGreen(scenarioDetail.Name), green("Flags"))
+		printHelp(*scenarioDetail)
+		fmt.Print("\n\n")
+	})
+
 	return command
 }
 
+var groupDisplayOrder = []string{"general", "prometheus", "elasticsearch", "cerberus", "telemetry", "health_check", "kubevirt", "resiliency"}
+
 func printHelp(scenario models.ScenarioDetail) {
 	boldWhite := color.New(color.FgHiWhite, color.Bold).SprintFunc()
-	for _, f := range scenario.Fields {
+	boldCyan := color.New(color.FgCyan, color.Bold).SprintFunc()
 
-		enum := ""
-		if f.Type == typing.Enum {
-			enum = strings.Replace(*f.AllowedValues, *f.Separator, "|", -1)
-		}
-		def := ""
-		if f.Default != nil && *f.Default != "" {
-			def = fmt.Sprintf("(Default: %s)", *f.Default)
-		}
+	grouped := typing.GroupFieldsByGroup(scenario.Fields)
 
-		fmt.Printf("\t--%s %s: %s [%s]%s\n", *f.Name, boldWhite(enum), *f.Description, boldWhite(f.Type.String()), def)
+	// if no field has a group, print flat (scenario flags case)
+	if len(grouped) == 1 {
+		if fields, ok := grouped[""]; ok {
+			for _, f := range fields {
+				printHelpField(f, boldWhite)
+			}
+			return
+		}
 	}
+
+	// print ungrouped fields first (no section header)
+	if ungrouped, ok := grouped[""]; ok {
+		for _, f := range ungrouped {
+			printHelpField(f, boldWhite)
+		}
+	}
+
+	// print known groups in canonical order
+	printed := make(map[string]bool)
+	for _, g := range groupDisplayOrder {
+		if fields, ok := grouped[g]; ok {
+			fmt.Printf("\n\t%s\n", boldCyan(groupLabel(g)))
+			for _, f := range fields {
+				printHelpField(f, boldWhite)
+			}
+			printed[g] = true
+		}
+	}
+
+	// print any remaining unknown groups alphabetically
+	remaining := make([]string, 0)
+	for g := range grouped {
+		if g != "" && !printed[g] {
+			remaining = append(remaining, g)
+		}
+	}
+	sort.Strings(remaining)
+	for _, g := range remaining {
+		fmt.Printf("\n\t%s\n", boldCyan(groupLabel(g)))
+		for _, f := range grouped[g] {
+			printHelpField(f, boldWhite)
+		}
+	}
+}
+
+func groupLabel(g string) string {
+	return strings.ToUpper(strings.ReplaceAll(g, "_", " "))
+}
+
+func printHelpField(f typing.InputField, boldWhite func(a ...interface{}) string) {
+	enum := ""
+	if f.Type == typing.Enum && f.AllowedValues != nil {
+		separator := ","
+		if f.Separator != nil {
+			separator = *f.Separator
+		}
+		enum = strings.Replace(*f.AllowedValues, separator, "|", -1)
+	}
+	def := ""
+	if f.Default != nil && *f.Default != "" {
+		def = fmt.Sprintf("(Default: %s)", *f.Default)
+	}
+	fmt.Printf("\t--%s %s: %s [%s]%s\n", *f.Name, boldWhite(enum), *f.Description, boldWhite(f.Type.String()), def)
 }
 
 func parseScenarioName(args []string) (string, error) {

--- a/cmd/tables.go
+++ b/cmd/tables.go
@@ -2,14 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/fatih/color"
 	"github.com/krkn-chaos/krknctl/pkg/config"
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
 	orchestratormodels "github.com/krkn-chaos/krknctl/pkg/scenarioorchestrator/models"
 	"github.com/krkn-chaos/krknctl/pkg/scenarioorchestrator/utils"
 	"github.com/krkn-chaos/krknctl/pkg/typing"
-	"strings"
-	"time"
 )
 import "github.com/rodaine/table"
 
@@ -47,6 +49,47 @@ func NewArgumentTable(inputFields []typing.InputField) table.Table {
 		tbl.AddRow(fmt.Sprintf("--%s", *inputField.Name), inputField.Type.String(), *inputField.ShortDescription, inputField.Required, defaultValue)
 	}
 	return tbl
+}
+
+func PrintGroupedArgumentTables(inputFields []typing.InputField) {
+	groupOrder := []string{"general", "prometheus", "elasticsearch", "cerberus", "telemetry", "health_check", "kubevirt", "resiliency"}
+	sectionFmt := color.New(color.FgCyan, color.Bold).SprintfFunc()
+
+	grouped := typing.GroupFieldsByGroup(inputFields)
+
+	// if nothing has a group, fall back to a single flat table
+	if len(grouped) == 1 {
+		if fields, ok := grouped[""]; ok {
+			NewArgumentTable(fields).Print()
+			return
+		}
+	}
+
+	// ungrouped fields first
+	if ungrouped, ok := grouped[""]; ok {
+		NewArgumentTable(ungrouped).Print()
+	}
+
+	printed := make(map[string]bool)
+	for _, g := range groupOrder {
+		if fields, ok := grouped[g]; ok {
+			fmt.Printf("\n%s\n", sectionFmt(strings.ToUpper(strings.ReplaceAll(g, "_", " "))))
+			NewArgumentTable(fields).Print()
+			printed[g] = true
+		}
+	}
+
+	remaining := make([]string, 0)
+	for g := range grouped {
+		if g != "" && !printed[g] {
+			remaining = append(remaining, g)
+		}
+	}
+	sort.Strings(remaining)
+	for _, g := range remaining {
+		fmt.Printf("\n%s\n", sectionFmt(strings.ToUpper(strings.ReplaceAll(g, "_", " "))))
+		NewArgumentTable(grouped[g]).Print()
+	}
 }
 
 func NewEnvironmentTable(env map[string]ParsedField, config config.Config) table.Table {

--- a/pkg/provider/models/models.go
+++ b/pkg/provider/models/models.go
@@ -167,3 +167,7 @@ func (s *ScenarioDetail) GetFileFieldByMountPath(mountPath string) *typing.Input
 	}
 	return nil
 }
+
+func (s *ScenarioDetail) GetFieldsByGroup() map[string][]typing.InputField {
+	return typing.GroupFieldsByGroup(s.Fields)
+}

--- a/pkg/typing/field.go
+++ b/pkg/typing/field.go
@@ -32,6 +32,7 @@ type InputField struct {
 	Requires          *string `json:"requires,omitempty"`
 	MutuallyExcludes  *string `json:"mutually_excludes,omitempty"`
 	Secret            bool    `json:"secret,omitempty"`
+	Group             *string `json:"group,omitempty"`
 }
 
 type alias InputField
@@ -112,6 +113,10 @@ func (f *InputField) UnmarshalJSON(data []byte) error {
 		f.Secret = secret
 	} else {
 		f.Secret = false
+	}
+
+	if fieldProperty, ok := temp["group"]; ok {
+		f.Group = &fieldProperty
 	}
 
 	return nil
@@ -238,4 +243,18 @@ func (f *InputField) Validate(value *string) (*string, error) {
 		}
 	}
 	return selectedValue, deferErr
+}
+
+// GroupFieldsByGroup organizes a slice of InputFields into a map keyed by group name.
+// Fields without a group are placed under the empty string key.
+func GroupFieldsByGroup(fields []InputField) map[string][]InputField {
+	groups := make(map[string][]InputField)
+	for _, field := range fields {
+		group := ""
+		if field.Group != nil {
+			group = *field.Group
+		}
+		groups[group] = append(groups[group], field)
+	}
+	return groups
 }

--- a/pkg/typing/field_test.go
+++ b/pkg/typing/field_test.go
@@ -606,6 +606,141 @@ func TestFieldFile(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestGroupField(t *testing.T) {
+	var field InputField
+	var err error
+
+	fieldWithGroup := `
+{
+	"name": "prometheus-url",
+	"short_description": "Prometheus url",
+	"description": "Prometheus url for when running on kubernetes",
+	"variable": "PROMETHEUS_URL",
+	"type": "string",
+	"default": "",
+	"required": "false",
+	"group": "prometheus"
+}
+`
+	err = json.Unmarshal([]byte(fieldWithGroup), &field)
+	assert.Nil(t, err)
+	assert.NotNil(t, field.Group)
+	assert.Equal(t, "prometheus", *field.Group)
+
+	// marshal preserves group
+	data, err := json.Marshal(&field)
+	assert.Nil(t, err)
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, "prometheus", result["group"])
+
+	// round-trip preserves group
+	var field2 InputField
+	err = json.Unmarshal(data, &field2)
+	assert.Nil(t, err)
+	assert.NotNil(t, field2.Group)
+	assert.Equal(t, *field.Group, *field2.Group)
+
+	// group is optional — field without group parses fine and group is nil
+	field = InputField{}
+	fieldWithoutGroup := `
+{
+	"name": "wait-duration",
+	"short_description": "Post chaos wait duration",
+	"description": "waits for a certain amount of time after the scenario",
+	"variable": "WAIT_DURATION",
+	"type": "number",
+	"default": "1"
+}
+`
+	err = json.Unmarshal([]byte(fieldWithoutGroup), &field)
+	assert.Nil(t, err)
+	assert.Nil(t, field.Group)
+
+	// group is omitted from marshaled output when nil
+	data, err = json.Marshal(&field)
+	assert.Nil(t, err)
+	result = map[string]interface{}{}
+	err = json.Unmarshal(data, &result)
+	assert.Nil(t, err)
+	_, groupPresent := result["group"]
+	assert.False(t, groupPresent)
+
+	// all known group values round-trip correctly
+	knownGroups := []string{"general", "prometheus", "elasticsearch", "cerberus", "telemetry", "health_check", "kubevirt", "resiliency"}
+	baseJSON := `{"name":"field","variable":"VAR","type":"string","group":"%s"}`
+	for _, group := range knownGroups {
+		field = InputField{}
+		err = json.Unmarshal([]byte(fmt.Sprintf(baseJSON, group)), &field)
+		assert.Nil(t, err, "group %q failed to unmarshal", group)
+		assert.NotNil(t, field.Group)
+		assert.Equal(t, group, *field.Group)
+
+		data, err = json.Marshal(&field)
+		assert.Nil(t, err)
+		result = map[string]interface{}{}
+		err = json.Unmarshal(data, &result)
+		assert.Nil(t, err)
+		assert.Equal(t, group, result["group"])
+	}
+}
+
+func TestGroupFieldsByGroup(t *testing.T) {
+	makeField := func(name, variable, group string) InputField {
+		n, v := name, variable
+		f := InputField{Name: &n, Variable: &v, Type: String}
+		if group != "" {
+			g := group
+			f.Group = &g
+		}
+		return f
+	}
+
+	// empty input returns empty map
+	result := GroupFieldsByGroup([]InputField{})
+	assert.Empty(t, result)
+
+	// fields without a group land under the empty string key
+	noGroupField := makeField("wait-duration", "WAIT_DURATION", "")
+	result = GroupFieldsByGroup([]InputField{noGroupField})
+	assert.Len(t, result, 1)
+	assert.Len(t, result[""], 1)
+	assert.Equal(t, "wait-duration", *result[""][0].Name)
+
+	// fields with a group are keyed by that group
+	prometheusField := makeField("prometheus-url", "PROMETHEUS_URL", "prometheus")
+	result = GroupFieldsByGroup([]InputField{prometheusField})
+	assert.Len(t, result, 1)
+	assert.Len(t, result["prometheus"], 1)
+	assert.Equal(t, "prometheus-url", *result["prometheus"][0].Name)
+
+	// multiple fields in the same group stay together
+	prometheusToken := makeField("prometheus-token", "PROMETHEUS_TOKEN", "prometheus")
+	result = GroupFieldsByGroup([]InputField{prometheusField, prometheusToken})
+	assert.Len(t, result, 1)
+	assert.Len(t, result["prometheus"], 2)
+
+	// fields across multiple groups are organized independently
+	esField := makeField("es-server", "ES_SERVER", "elasticsearch")
+	telField := makeField("telemetry-enabled", "TELEMETRY_ENABLED", "telemetry")
+	generalField := makeField("uuid", "UUID", "general")
+	ungroupedField := makeField("wait-duration", "WAIT_DURATION", "")
+
+	allFields := []InputField{prometheusField, prometheusToken, esField, telField, generalField, ungroupedField}
+	result = GroupFieldsByGroup(allFields)
+	assert.Len(t, result, 5)
+	assert.Len(t, result["prometheus"], 2)
+	assert.Len(t, result["elasticsearch"], 1)
+	assert.Len(t, result["telemetry"], 1)
+	assert.Len(t, result["general"], 1)
+	assert.Len(t, result[""], 1)
+
+	// order within each group matches insertion order
+	assert.Equal(t, "prometheus-url", *result["prometheus"][0].Name)
+	assert.Equal(t, "prometheus-token", *result["prometheus"][1].Name)
+}
+
 func TestMarshalJSON(t *testing.T) {
 	name := "test-field"
 	variable := "TEST_VAR"


### PR DESCRIPTION
## Description  
Adding grouping to global parameters from krknctl-input.json 'group' field 

```
% ./krknctl run pod-scenarios --help                                   
📣📦 a newer version of krknctl, v0.12.0-beta, is currently available, check it out! https://github.com/krkn-chaos/krknctl/releases/latest


container runtime: Podman

Krkn Global flags

        GENERAL
        --ssh-public-key : Sets the path where krkn will search for ssh public key (in container) [string]
        --ssh-private-key : Sets the path where krkn will search for ssh private key (in container) [string]
        --krkn-kubeconfig : Sets the path where krkn will search for kubeconfig (in container) [string](Default: /home/krkn/.kube/config)
        --wait-duration : waits for a certain amount of time after the scenario [number](Default: 1)
        --iterations : number of times the same chaos scenario will be executed [number](Default: 1)
        --daemon-mode True|False: if set the scenario will execute forever [enum](Default: False)
        --uuid : sets krkn run uuid instead of generating it [string]
        --krkn-debug True|False: Enables debug mode for Krkn [enum](Default: False)

        PROMETHEUS
        --prometheus-url : Prometheus url for when running on kuberenetes [string]
        --prometheus-token : Prometheus bearer token for prometheus url authentication [string]
        --capture-metrics True|False: Enables metrics capture [enum](Default: False)
        --enable-alerts True|False: Enables cluster alerts check [enum](Default: False)
        --alerts-path : Allows to specify a different alert file path [string](Default: config/alerts.yaml)
        --metrics-path : Allows to specify a different metrics file path [string](Default: config/metrics-aggregated.yaml)
        --check-critical-alerts True|False: Enables checking for critical alerts [enum](Default: False)

        ELASTICSEARCH
        --enable-es True|False: Enables elastic search data collection [enum](Default: False)
        --es-run-tag : Elasticsearch run tag to compare similar runs [string]
        --es-server : Elasticsearch instance URL [string](Default: http://0.0.0.0)
        --es-port : Elasticsearch instance port [number](Default: 443)
        --es-username : Elasticsearch instance username [string](Default: elastic)
        --es-password : Elasticsearch instance password [string]
        --es-verify-certs True|False: Enables elasticsearch TLS certificate verification [enum](Default: False)
        --es-metrics-index : Index name for metrics in Elasticsearch [string](Default: krkn-metrics)
        --es-alerts-index : Index name for alerts in Elasticsearch [string](Default: krkn-alerts)
        --es-telemetry-index : Index name for telemetry in Elasticsearch [string](Default: krkn-telemetry)

        CERBERUS
        --cerberus-enabled True|False: Enables Cerberus Support [enum](Default: False)
        --cerberus-url : Cerberus http url [string](Default: http://0.0.0.0:8080)

        TELEMETRY
        --telemetry-enabled True|False: Enables telemetry support [enum](Default: False)
        --telemetry-api-url : API endpoint for telemetry data [string](Default: https://ulnmf9xv7j.execute-api.us-west-2.amazonaws.com/production)
        --telemetry-username : Username for telemetry authentication [string](Default: redhat-chaos)
        --telemetry-password : Password for telemetry authentication [string]
        --telemetry-prometheus-backup True|False: Enables Prometheus backup for telemetry [enum](Default: True)
        --telemetry-full-prometheus-backup True|False: Enables full Prometheus backup for telemetry [enum](Default: False)
        --telemetry-backup-threads : Number of threads for telemetry backup [number](Default: 5)
        --telemetry-archive-path : Path to save telemetry archive [string](Default: /tmp)
        --telemetry-max-retries : Maximum retries for telemetry operations [number](Default: 0)
        --telemetry-run-tag : Tag for telemetry run [string](Default: chaos)
        --telemetry-group : Group name for telemetry data [string](Default: default)
        --telemetry-archive-size : Maximum size for telemetry archives [number](Default: 1000)
        --telemetry-logs-backup True|False: Enables logs backup for telemetry [enum](Default: False)
        --telemetry-filter-pattern : Filter pattern for telemetry logs [string](Default: ["(\\w{3}\\s\\d{1,2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d+).+","kinit (\\d+/\\d+/\\d+\\s\\d{2}:\\d{2}:\\d{2})\\s+","(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z).+"])
        --telemetry-cli-path : Path to telemetry CLI tool (oc) [string]
        --telemetry-events-backup True|False: Enables events backup for telemetry [enum](Default: True)

        HEALTH CHECK
        --health-check-interval : How often to check the health check urls [number](Default: 2)
        --health-check-url : Url to check the health of [string]
        --health-check-auth : Authentication tuple to authenticate into health check URL [string]
        --health-check-bearer-token : Bearer token to authenticate into health check URL [string]
        --health-check-exit True|False: Exit on failure when health check URL is not able to connect [enum](Default: False)
        --health-check-verify True|False: SSL Verification to authenticate into health check URL [enum](Default: False)

        KUBEVIRT
        --kubevirt-check-interval : How often to check the kube virt check Vms ssh status [number](Default: 2)
        --kubevirt-namespace : KubeVirt namespace to check the health of [string]
        --kubevirt-name : KubeVirt regex names to check VMs [string]
        --kubevirt-only-failures True|False|true|false: KubeVirt checks only report if failure occurs [enum](Default: False)
        --kubevirt-disconnected True|False|true|false: KubeVirt checks in disconnected mode, bypassing the clusters Api [enum](Default: False)
        --kubevirt-ssh-node : KubeVirt node to ssh from, should be available whole chaos run [string]
        --kubevirt-exit-on-failure True|False|true|false: KubeVirt fails run if vms still have false status [enum](Default: False)
        --kubevirt-node-name : Only track VMs in KubeVirt on given node name [string]
        --kubevirt-label-selector : Label selector to filter VMs in KubeVirt [string]

        RESILIENCY
        --resiliency-score : The system outputs a detailed resiliency score as a single-line JSON object, facilitating easy aggregation across multiple test scenarios. [boolean]
        --disable-resiliency-score : Disable resiliency score calculation [boolean]
        --resiliency-file : Custom Resiliency score file [file]

pod-scenarios Flags
        --namespace : Targeted namespace in the cluster ( supports regex ) [string](Default: openshift-.*)
        --node-names : Node names to target [string]
        --node-label-selector : Label selector to target nodes [string]
        --pod-label : Label of the pod(s) to target [string]
        --exclude-label : Label for excluding one or more pods from chaos [string]
        --name-pattern : Regex pattern to match the pods in NAMESPACE when POD_LABEL is not specified [string](Default: .*)
        --disruption-count : Number of pods to disrupt [number](Default: 1)
        --kill-timeout : Timeout to wait for the target pod(s) to be removed in seconds [number](Default: 180)
        --expected-recovery-time : Fails if the pod disrupted do not recover within the timeout set [number](Default: 120)
```


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  