### PR TITLE
adds --dry-run=client

### DIFF
--- a/cmd/dry_run.go
+++ b/cmd/dry_run.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+)
+
+func ValidateScenarioConfig(scenarioDetail *models.ScenarioDetail, globalDetail *models.ScenarioDetail, args []string) (bool, []string) {
+	var validationErrors []string
+
+	checkFields := func(detail *models.ScenarioDetail, skipDefault bool) {
+		if detail == nil {
+			return
+		}
+		for i := range detail.Fields {
+			field := &detail.Fields[i]
+			if field.Name == nil {
+				continue
+			}
+			flagName := fmt.Sprintf("--%s", *field.Name)
+			value, found, err := ParseArgValue(args, flagName)
+			if err != nil {
+				validationErrors = append(validationErrors, fmt.Sprintf("field `%s`: %s", *field.Name, err.Error()))
+				continue
+			}
+
+			if !found && skipDefault {
+				continue
+			}
+
+			var valuePtr *string
+			if found {
+				valuePtr = &value
+			}
+
+			if _, err := field.Validate(valuePtr); err != nil {
+				validationErrors = append(validationErrors, fmt.Sprintf("field `%s`: %s", *field.Name, err.Error()))
+			}
+		}
+	}
+
+	checkFields(scenarioDetail, false)
+	checkFields(globalDetail, true)
+
+	return len(validationErrors) == 0, validationErrors
+}
+
+func PrintDryRunResult(valid bool, validationErrors []string) error {
+	if valid {
+		for _, line := range []string{"✔ Scenario schema valid", "✔ All required fields present", "✔ Values validated"} {
+			if _, err := color.New(color.FgGreen).Println(line); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, e := range validationErrors {
+		if _, err := color.New(color.FgRed).Println(fmt.Sprintf("✖ %s", e)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/dryrun_test.go
+++ b/cmd/dryrun_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	providerModels "github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/krkn-chaos/krknctl/pkg/typing"
+	"github.com/stretchr/testify/assert"
+)
+
+// 🤖 Assisted with Claude Code (claude.ai/code)
+
+func unmarshalField(t *testing.T, raw string) typing.InputField {
+	var field typing.InputField
+	err := json.Unmarshal([]byte(raw), &field)
+	assert.Nil(t, err)
+	return field
+}
+
+func TestValidateScenarioConfig(t *testing.T) {
+	requiredNoDefault := unmarshalField(t, `
+	{
+		"name":"namespace",
+		"short_description":"Namespace",
+		"description":"Namespace",
+		"variable":"NAMESPACE",
+		"type":"string",
+		"required":"true"
+	}`)
+
+	requiredWithDefault := unmarshalField(t, `
+	{
+		"name":"disruption-count",
+		"short_description":"Disruption count",
+		"description":"Disruption count",
+		"variable":"DISRUPTION_COUNT",
+		"type":"number",
+		"required":"true",
+		"default":"1"
+	}`)
+
+	optionalNumber := unmarshalField(t, `
+	{
+		"name":"kill-timeout",
+		"short_description":"Kill timeout",
+		"description":"Kill timeout",
+		"variable":"KILL_TIMEOUT",
+		"type":"number",
+		"default":"180"
+	}`)
+
+	trafficType := unmarshalField(t, `
+	{
+		"name":"traffic-type",
+		"short_description":"Traffic Type",
+		"description":"Traffic Type",
+		"variable":"TRAFFIC_TYPE",
+		"type":"enum",
+		"allowed_values":"ingress,egress",
+		"separator":",",
+		"required":"true"
+	}`)
+
+	requiredGlobal := unmarshalField(t, `
+	{
+		"name":"kubeconfig",
+		"short_description":"kubeconfig",
+		"description":"kubeconfig",
+		"variable":"KUBECONFIG",
+		"type":"string",
+		"required":"true"
+	}`)
+
+	requiredGlobalNumber := unmarshalField(t, `
+	{
+		"name":"wait-duration",
+		"short_description":"wait duration",
+		"description":"wait duration",
+		"variable":"WAIT_DURATION",
+		"type":"number",
+		"required":"true"
+	}`)
+
+	// happy path: all required fields provided
+	scenario := &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredNoDefault, trafficType},
+	}
+	args := []string{"--namespace", "dev", "--traffic-type", "egress"}
+	valid, errs := ValidateScenarioConfig(scenario, nil, args)
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+
+	// missing required field
+	scenario = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredNoDefault},
+	}
+	valid, errs = ValidateScenarioConfig(scenario, nil, []string{})
+	assert.False(t, valid)
+	assert.Len(t, errs, 1)
+
+	// required field filled by schema default
+	scenario = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredWithDefault},
+	}
+	valid, errs = ValidateScenarioConfig(scenario, nil, []string{})
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+
+	// invalid number value
+	scenario = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{optionalNumber},
+	}
+	args = []string{"--kill-timeout", "notanumber"}
+	valid, errs = ValidateScenarioConfig(scenario, nil, args)
+	assert.False(t, valid)
+	assert.Len(t, errs, 1)
+
+	// invalid enum value
+	scenario = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{trafficType},
+	}
+	args = []string{"--traffic-type", "not-a-real-choice"}
+	valid, errs = ValidateScenarioConfig(scenario, nil, args)
+	assert.False(t, valid)
+	assert.Len(t, errs, 1)
+
+	// explicitly empty string satisfies a required String field: Validate
+	// only treats a nil pointer as missing for Type==String
+	// (pkg/typing/field.go), and dry-run intentionally mirrors that
+	// exact behavior rather than adding a stricter check of its own, so
+	// it stays a faithful predictor of the real run path
+	global := &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredGlobal},
+	}
+	args = []string{"--kubeconfig", ""}
+	valid, errs = ValidateScenarioConfig(nil, global, args)
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+
+	// explicitly empty value fails a required non-String global field
+	global = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredGlobalNumber},
+	}
+	args = []string{"--wait-duration", ""}
+	valid, errs = ValidateScenarioConfig(nil, global, args)
+	assert.False(t, valid)
+	assert.Len(t, errs, 1)
+
+	// required global field not passed at all is skipped, mirroring
+	// ParseFlags' skipDefault=true behavior for globals on the real run
+	// path
+	global = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredGlobal},
+	}
+	valid, errs = ValidateScenarioConfig(nil, global, []string{})
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+
+	// multiple independent errors collected in one call
+	scenario = &providerModels.ScenarioDetail{
+		Fields: []typing.InputField{requiredNoDefault, trafficType},
+	}
+	args = []string{"--traffic-type", "not-a-real-choice"}
+	valid, errs = ValidateScenarioConfig(scenario, nil, args)
+	assert.False(t, valid)
+	assert.Len(t, errs, 2)
+}
+
+func TestPrintDryRunResult(t *testing.T) {
+	// valid result prints without error
+	err := PrintDryRunResult(true, nil)
+	assert.Nil(t, err)
+
+	// invalid result prints without error
+	err = PrintDryRunResult(false, []string{"missing required field: namespace"})
+	assert.Nil(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func Execute(providerFactory *factory.ProviderFactory, scenarioOrchestrator *sce
 	runCmd.LocalFlags().String("metrics-profile", "", "custom metrics profile file path")
 	runCmd.LocalFlags().Bool("detached", false, "if set this flag will run in detached mode")
 	runCmd.LocalFlags().Bool("form", false, "Use interactive form to collect scenario parameters instead of CLI flags")
+	runCmd.LocalFlags().Bool("dry-run", false, "validate the scenario configuration locally (schema, required fields, value constraints) without cluster access, kubeconfig, image pulls, or execution")
 	runCmd.DisableFlagParsing = true
 	rootCmd.AddCommand(runCmd)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -151,7 +151,16 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 				return err
 			}
 
-			(*scenarioOrchestrator).PrintContainerRuntime()
+			dryRun := false
+			for _, a := range args {
+				if a == "--dry-run" {
+					dryRun = true
+					break
+				}
+			}
+			if !dryRun {
+				(*scenarioOrchestrator).PrintContainerRuntime()
+			}
 			spinner := NewSpinnerWithSuffix("fetching scenario metadata...")
 			spinner.Start()
 
@@ -167,6 +176,17 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 			if err != nil {
 				spinner.Stop()
 				return err
+			}
+			if dryRun {
+				spinner.Stop()
+				valid, validationErrors := ValidateScenarioConfig(scenarioDetail, globalDetail, args)
+				if err := PrintDryRunResult(valid, validationErrors); err != nil {
+					return err
+				}
+				if !valid {
+					os.Exit(1)
+				}
+				return nil
 			}
 
 			environment := make(map[string]string)


### PR DESCRIPTION
## Description  

Adds a `--dry-run=client` mode to `krknctl run` that validates a scenario's
configuration locally

## Documentation  
- [ ] **Is documentation needed for this update?**
Yes

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  
Made a PR on the website too.

<img width="1357" height="100" alt="image" src="https://github.com/user-attachments/assets/b8c6727f-fb18-4815-8c20-7255ad126c29" />

fixes #117 