### PR TITLE
feat: add Group type to typing system

### DIFF
--- a/pkg/typing/field.go
+++ b/pkg/typing/field.go
@@ -16,6 +16,9 @@ import (
 
 const MaxFileSize int64 = 10_485_760
 
+// InputField represents a single field in a scenario input schema.
+// Fields can represent user input (string, number, boolean, enum, file)
+// or metadata for organizing fields into logical groups (group type).
 type InputField struct {
 	Name              *string `json:"name"`
 	ShortDescription  *string `json:"short_description,omitempty"`
@@ -32,7 +35,11 @@ type InputField struct {
 	Requires          *string `json:"requires,omitempty"`
 	MutuallyExcludes  *string `json:"mutually_excludes,omitempty"`
 	Secret            bool    `json:"secret,omitempty"`
-	Group             *string `json:"group,omitempty"`
+	// Group specifies the logical grouping for this field.
+	// Fields with the same Group value are related and should be presented together.
+	// When Type is "group", this field IS a group definition containing metadata;
+	// otherwise, this field references which group it belongs to.
+	Group *string `json:"group,omitempty"`
 }
 
 type alias InputField
@@ -239,9 +246,14 @@ func (f *InputField) Validate(value *string) (*string, error) {
 				return nil, errors.New("file `" + *selectedValue + "` is not a file or is not accessible")
 			}
 		case Group:
-			// Group is a special metadata type used to define field groupings.
-			// It does not require user input validation and is always valid.
-			// The value can be any string describing the group metadata.
+			// Group is a special metadata type used to define field grouping information.
+			// Unlike other types that validate user input, Group fields store metadata
+			// describing a collection of related fields (e.g., title, short description,
+			// long description, icons, etc.). This metadata is consumed by frontend
+			// applications to organize and present fields with rich UI grouping.
+			//
+			// Since Group fields contain metadata rather than user input, any string
+			// value is considered valid. No format validation or constraints are applied.
 			return selectedValue, nil
 		default:
 			return nil, errors.New("impossible to validate object")

--- a/pkg/typing/field.go
+++ b/pkg/typing/field.go
@@ -238,6 +238,11 @@ func (f *InputField) Validate(value *string) (*string, error) {
 			} else {
 				return nil, errors.New("file `" + *selectedValue + "` is not a file or is not accessible")
 			}
+		case Group:
+			// Group is a special metadata type used to define field groupings.
+			// It does not require user input validation and is always valid.
+			// The value can be any string describing the group metadata.
+			return selectedValue, nil
 		default:
 			return nil, errors.New("impossible to validate object")
 		}

--- a/pkg/typing/field_test.go
+++ b/pkg/typing/field_test.go
@@ -741,6 +741,76 @@ func TestGroupFieldsByGroup(t *testing.T) {
 	assert.Equal(t, "prometheus-token", *result["prometheus"][1].Name)
 }
 
+func TestGroupTypeValidation(t *testing.T) {
+	var field InputField
+	var value *string
+	var err error
+
+	// Group type field definition
+	groupField := `
+{
+	"name": "prometheus-config",
+	"short_description": "Prometheus Configuration Group",
+	"description": "Configuration group for Prometheus monitoring settings including URL, token, and retention",
+	"variable": "PROMETHEUS_GROUP",
+	"type": "group",
+	"default": "{\"title\":\"Prometheus\",\"description\":\"Monitoring configuration\"}"
+}
+`
+	err = json.Unmarshal([]byte(groupField), &field)
+	assert.Nil(t, err)
+	assert.Equal(t, Group, field.Type)
+
+	// Group type accepts any string value (it's metadata)
+	testValue := "{\"title\":\"Test Group\",\"short_desc\":\"Test\"}"
+	value, err = field.Validate(&testValue)
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	assert.Equal(t, testValue, *value)
+
+	// Group type works with default value
+	value, err = field.Validate(nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	assert.Equal(t, "{\"title\":\"Prometheus\",\"description\":\"Monitoring configuration\"}", *value)
+
+	// Group type with empty string falls back to default (standard behavior)
+	emptyValue := ""
+	value, err = field.Validate(&emptyValue)
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	// Empty value triggers default for non-string types
+	assert.Equal(t, "{\"title\":\"Prometheus\",\"description\":\"Monitoring configuration\"}", *value)
+
+	// Group type field without default and not required accepts nil
+	field = InputField{}
+	groupFieldNoDefault := `
+{
+	"name": "optional-group",
+	"variable": "OPTIONAL_GROUP",
+	"type": "group",
+	"required": "false"
+}
+`
+	err = json.Unmarshal([]byte(groupFieldNoDefault), &field)
+	assert.Nil(t, err)
+	value, err = field.Validate(nil)
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	// Group type marshals correctly
+	field = InputField{}
+	err = json.Unmarshal([]byte(groupField), &field)
+	assert.Nil(t, err)
+	data, err := json.Marshal(&field)
+	assert.Nil(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, "group", result["type"])
+}
+
 func TestMarshalJSON(t *testing.T) {
 	name := "test-field"
 	variable := "TEST_VAR"

--- a/pkg/typing/types.go
+++ b/pkg/typing/types.go
@@ -19,6 +19,7 @@ const (
 	Unknown
 	File
 	FileBase64
+	Group
 )
 
 func (t Type) String() string {
@@ -35,6 +36,8 @@ func (t Type) String() string {
 		return "file"
 	case FileBase64:
 		return "file_base64"
+	case Group:
+		return "group"
 	default:
 		return "unknown"
 	}
@@ -54,6 +57,8 @@ func ToType(s string) Type {
 		return File
 	case "file_base64":
 		return FileBase64
+	case "group":
+		return Group
 	default:
 		return Unknown
 	}

--- a/pkg/typing/types.go
+++ b/pkg/typing/types.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+// Type represents the data type of an InputField.
+// Each type determines how values are validated and processed.
 type Type int64
 
 const (
@@ -19,6 +21,11 @@ const (
 	Unknown
 	File
 	FileBase64
+	// Group is a special metadata type used to define field grouping information.
+	// Unlike other types that validate user input, Group fields contain metadata
+	// about a group of fields (e.g., title, short description, long description).
+	// This type is primarily used by frontend applications to organize and present
+	// related fields together with rich descriptive information.
 	Group
 )
 

--- a/pkg/typing/types_test.go
+++ b/pkg/typing/types_test.go
@@ -64,6 +64,10 @@ func TestToType(t *testing.T) {
 	assert.Equal(t, krknctlType.String(), "file_base64")
 	assert.Equal(t, ToType("file_base64"), krknctlType)
 
+	krknctlType = Group
+	assert.Equal(t, krknctlType.String(), "group")
+	assert.Equal(t, ToType("group"), krknctlType)
+
 	assert.Equal(t, ToType("anything"), Unknown)
 
 }


### PR DESCRIPTION
## Summary

Added a new **Group** type to the typing system to provide rich metadata for field groupings. This special type is designed to give the frontend detailed information about field groups, including title, short description, long description, and other descriptive metadata.

## Motivation

Following the addition of the `group` attribute to the `Field` struct, a dedicated `Group` type was needed to provide a complete definition of the groups to which a field can belong. This enables better organization and presentation of related fields in the UI.

## Changes

- ✅ Added `Group` constant to the `Type` enum
- ✅ Updated `Type.String()` method to handle Group type  
- ✅ Updated `ToType()` function to parse "group" string
- ✅ Added comprehensive unit tests for Group type

## Test Plan

- [x] Code compiles successfully
- [x] All existing tests pass
- [x] New unit tests added and passing for Group type
- [x] Verified round-trip conversion (Type → string → Type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)