### PR TITLE
feat(provider): parse is_a_scenario and has_rollback in Quay provider

### DIFF
--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -17,10 +17,16 @@ import (
 )
 
 func GetKrknctlLabel(label string, layers []ContainerLayer) *string {
+	trimmedLabel := strings.TrimSuffix(label, "=")
+	exactMatch := fmt.Sprintf("LABEL %s", label)
+	spaceMatch := fmt.Sprintf("LABEL %s ", trimmedLabel)
+	tabMatch := fmt.Sprintf("LABEL %s\t", trimmedLabel)
 	for _, v := range layers {
 		commands := v.GetCommands()
 		for _, c := range commands {
-			if strings.Contains(c, fmt.Sprintf("LABEL %s", label)) {
+			if strings.Contains(c, exactMatch) ||
+				strings.Contains(c, spaceMatch) ||
+				strings.Contains(c, tabMatch) {
 				return &c
 			}
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -91,6 +91,38 @@ func parseBoolLabel(s string, regex string, labelName string) (*bool, error) {
 	return &boolValue, nil
 }
 
+// PopulateBooleanLabels parses is_a_scenario and has_rollback labels from container layers
+// and sets them on the ScenarioDetail. Only applies to non-global environments.
+func (p *BaseScenarioProvider) PopulateBooleanLabels(detail *models.ScenarioDetail, layers []ContainerLayer, isGlobalEnvironment bool) error {
+	if isGlobalEnvironment {
+		return nil
+	}
+
+	foundIsAScenario := GetKrknctlLabel(p.Config.LabelIsAScenario, layers)
+	if foundIsAScenario != nil {
+		parsed, err := p.ParseIsAScenario(*foundIsAScenario)
+		if err != nil {
+			return err
+		}
+		detail.IsAScenario = *parsed
+	} else {
+		detail.IsAScenario = false
+	}
+
+	foundHasRollback := GetKrknctlLabel(p.Config.LabelHasRollback, layers)
+	if foundHasRollback != nil {
+		parsed, err := p.ParseHasRollback(*foundHasRollback)
+		if err != nil {
+			return err
+		}
+		detail.HasRollback = *parsed
+	} else {
+		detail.HasRollback = false
+	}
+
+	return nil
+}
+
 func (p *BaseScenarioProvider) ParseInputFields(s string, isGlobalEnvironment bool) ([]typing.InputField, error) {
 	var regex = ""
 	if isGlobalEnvironment {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -94,6 +94,9 @@ func parseBoolLabel(s string, regex string, labelName string) (*bool, error) {
 // PopulateBooleanLabels parses is_a_scenario and has_rollback labels from container layers
 // and sets them on the ScenarioDetail. Only applies to non-global environments.
 func (p *BaseScenarioProvider) PopulateBooleanLabels(detail *models.ScenarioDetail, layers []ContainerLayer, isGlobalEnvironment bool) error {
+	if detail == nil {
+		return errors.New("scenario detail cannot be nil")
+	}
 	if isGlobalEnvironment {
 		return nil
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -142,3 +142,56 @@ func TestPopulateBooleanLabels_EmptyLayers(t *testing.T) {
 	assert.False(t, detail.IsAScenario)
 	assert.False(t, detail.HasRollback)
 }
+
+func TestPopulateBooleanLabels_NilDetail(t *testing.T) {
+	p := getTestProvider(t)
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{`LABEL krknctl.is_a_scenario="true"`}},
+	}
+
+	err := p.PopulateBooleanLabels(nil, layers, false)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "scenario detail cannot be nil")
+}
+
+func TestPopulateBooleanLabels_WhitespaceAroundEquals(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario = "true"`,
+			`LABEL krknctl.has_rollback = "false"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.True(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}
+
+func TestGetKrknctlLabel_WhitespaceAroundEquals(t *testing.T) {
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{`LABEL krknctl.is_a_scenario = "true"`}},
+	}
+	result := GetKrknctlLabel("krknctl.is_a_scenario=", layers)
+	assert.NotNil(t, result)
+	assert.Contains(t, *result, "krknctl.is_a_scenario")
+}
+
+func TestGetKrknctlLabel_NoTrailingEquals(t *testing.T) {
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{`LABEL krknctl.title="My Title"`}},
+	}
+	result := GetKrknctlLabel("krknctl.title=", layers)
+	assert.NotNil(t, result)
+	assert.Contains(t, *result, "My Title")
+}
+
+func TestGetKrknctlLabel_NotFound(t *testing.T) {
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{`LABEL krknctl.title="My Title"`}},
+	}
+	result := GetKrknctlLabel("krknctl.is_a_scenario=", layers)
+	assert.Nil(t, result)
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/krkn-chaos/krknctl/pkg/cache"
+	"github.com/krkn-chaos/krknctl/pkg/config"
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLayer struct {
+	commands []string
+}
+
+func (m mockLayer) GetCommands() []string {
+	return m.commands
+}
+
+func getTestProvider(t *testing.T) BaseScenarioProvider {
+	cfg, err := config.LoadConfig()
+	assert.Nil(t, err)
+	return BaseScenarioProvider{
+		Config: cfg,
+		Cache:  cache.NewCache(),
+	}
+}
+
+func TestPopulateBooleanLabels_BothTrue(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario="true"`,
+			`LABEL krknctl.has_rollback="true"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.True(t, detail.IsAScenario)
+	assert.True(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_BothFalse(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario="false"`,
+			`LABEL krknctl.has_rollback="false"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.False(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_MissingLabels(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.title="some title"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.False(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_GlobalEnvironment_Skipped(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario="true"`,
+			`LABEL krknctl.has_rollback="true"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, true)
+	assert.Nil(t, err)
+	assert.False(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_OnlyIsAScenario(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario="true"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.True(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_InvalidBoolValue(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{
+			`LABEL krknctl.is_a_scenario="notabool"`,
+		}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid boolean value")
+}
+
+func TestPopulateBooleanLabels_LabelsAcrossMultipleLayers(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	layers := []ContainerLayer{
+		mockLayer{commands: []string{`LABEL krknctl.is_a_scenario="true"`}},
+		mockLayer{commands: []string{`LABEL krknctl.has_rollback="true"`}},
+	}
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.True(t, detail.IsAScenario)
+	assert.True(t, detail.HasRollback)
+}
+
+func TestPopulateBooleanLabels_EmptyLayers(t *testing.T) {
+	p := getTestProvider(t)
+	detail := &models.ScenarioDetail{}
+	var layers []ContainerLayer
+
+	err := p.PopulateBooleanLabels(detail, layers, false)
+	assert.Nil(t, err)
+	assert.False(t, detail.IsAScenario)
+	assert.False(t, detail.HasRollback)
+}

--- a/pkg/provider/quay/scenario_provider.go
+++ b/pkg/provider/quay/scenario_provider.go
@@ -186,6 +186,11 @@ func (p *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	for _, l := range manifest.Layers {
 		layers = append(layers, l)
 	}
+
+	if err := p.BaseScenarioProvider.PopulateBooleanLabels(&scenarioDetail, layers, isGlobalEnvironment); err != nil {
+		return nil, err
+	}
+
 	foundTitle := provider.GetKrknctlLabel(titleLabel, layers)
 	foundDescription := provider.GetKrknctlLabel(descriptionLabel, layers)
 	foundInputFields := provider.GetKrknctlLabel(inputFieldsLabel, layers)

--- a/pkg/provider/registryv2/scenario_provider.go
+++ b/pkg/provider/registryv2/scenario_provider.go
@@ -452,32 +452,9 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	foundTitle := provider.GetKrknctlLabel(titleLabel, layers)
 	foundDescription := provider.GetKrknctlLabel(descriptionLabel, layers)
 	foundInputFields := provider.GetKrknctlLabel(inputFieldsLabel, layers)
-	if !isGlobalEnvironment {
 
-		foundIsAScenario := provider.GetKrknctlLabel(s.Config.LabelIsAScenario, layers)
-		foundHasRollback := provider.GetKrknctlLabel(s.Config.LabelHasRollback, layers)
-
-		if foundIsAScenario != nil {
-			parsedIsAScenario, err := s.ParseIsAScenario(*foundIsAScenario)
-			if err != nil {
-				return nil, err
-			}
-			scenarioDetail.IsAScenario = *parsedIsAScenario
-		} else {
-			scenarioDetail.IsAScenario = false
-		}
-
-		if foundHasRollback != nil {
-			parsedHasRollback, err := s.ParseHasRollback(*foundHasRollback)
-			if err != nil {
-				return nil, err
-			}
-
-			scenarioDetail.HasRollback = *parsedHasRollback
-		} else {
-			scenarioDetail.HasRollback = false
-		}
-
+	if err := s.BaseScenarioProvider.PopulateBooleanLabels(&scenarioDetail, layers, isGlobalEnvironment); err != nil {
+		return nil, err
 	}
 
 	if foundTitle == nil {


### PR DESCRIPTION
## Summary
- Extract `is_a_scenario` and `has_rollback` boolean label parsing from `registryv2.ScenarioProvider` into a shared `PopulateBooleanLabels` method on `BaseScenarioProvider`
- Add the same parsing to `quay.ScenarioProvider`, which previously did not populate these fields (defaulting to `false`)
- Both providers now use the shared method, eliminating code duplication

## Test plan
- [x] 8 unit tests for `PopulateBooleanLabels` covering: both true, both false, missing labels, global env skip, single label, invalid bool, multi-layer, empty layers
- [x] All existing provider tests pass (quay, registryv2, factory, models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)