### PR TITLE
fix(verify): print signature-verification result on a clean line

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -154,6 +154,21 @@ func NewRunCommand(factory *factory.ProviderFactory, scenarioOrchestrator *scena
 			spinner := NewSpinnerWithSuffix("fetching scenario metadata...")
 			spinner.Start()
 
+			// Let the signature-verification step (which runs inside the
+			// orchestrator's Run/RunAttached) pause this spinner so its
+			// verified/rejected message prints on a clean line instead of being
+			// appended to the spinner frame. Only pause when the spinner is
+			// actually running, and resume it afterwards so the pull progress
+			// keeps animating.
+			scenarioorchestrator.ProgressPauser = func() func() {
+				if !spinner.Active() {
+					return func() {}
+				}
+				spinner.Stop()
+				return func() { spinner.Start() }
+			}
+			defer func() { scenarioorchestrator.ProgressPauser = nil }()
+
 			runDetached := false
 
 			provider := GetProvider(registrySettings != nil, factory)

--- a/pkg/scenarioorchestrator/verify.go
+++ b/pkg/scenarioorchestrator/verify.go
@@ -11,6 +11,29 @@ import (
 	"github.com/krkn-chaos/krknctl/pkg/verify"
 )
 
+// ProgressPauser, when set by the CLI layer, is invoked immediately before any
+// verification result (verified, rejected, or the --run-unsigned-images bypass
+// warning) is written to stderr, and must return a resume callback that is
+// invoked once the message has been printed. It lets the run path stop an active
+// progress spinner so the full-width verification messages are not overwritten
+// or interleaved with the spinner frame, without coupling this package to a
+// concrete spinner implementation.
+//
+// It is left nil on paths that have no spinner to manage (e.g. graph runs and
+// tests); in that case pauseProgress is a no-op and verification prints
+// directly.
+var ProgressPauser func() (resume func())
+
+// pauseProgress invokes ProgressPauser if set and always returns a resume
+// callback safe to call (a no-op when no pauser is registered), so callers can
+// unconditionally `defer resume()`.
+func pauseProgress() (resume func()) {
+	if ProgressPauser == nil {
+		return func() {}
+	}
+	return ProgressPauser()
+}
+
 // VerifyAndPinImage verifies the cosign signature of image using the shared
 // ecosystem policy (pkg/verify) and returns the pinned digest reference that
 // MUST be run in place of the original tag. It fails closed: any verification
@@ -24,6 +47,10 @@ import (
 // uses.
 func VerifyAndPinImage(ctx context.Context, image string, registry *providermodels.RegistryV2) (string, error) {
 	verified, err := verify.VerifyImage(ctx, image, verify.OptionsForRegistry(registry))
+	// Stop any active progress spinner so the verification result prints on its
+	// own clean line rather than being appended to the spinner frame.
+	resume := pauseProgress()
+	defer resume()
 	if err != nil {
 		// Make the trust decision visible: an image is being refused, and why.
 		logRejectedImage(image, err)
@@ -46,7 +73,9 @@ func VerifyAndPinImage(ctx context.Context, image string, registry *providermode
 // command's stdout (e.g. piped or redirected report output).
 func VerifyAndPinImageOrBypass(ctx context.Context, image string, registry *providermodels.RegistryV2, allowUnsigned bool) (string, error) {
 	if allowUnsigned {
+		resume := pauseProgress()
 		warnUnsignedImage(image)
+		resume()
 		return image, nil
 	}
 	return VerifyAndPinImage(ctx, image, registry)

--- a/pkg/scenarioorchestrator/verify.go
+++ b/pkg/scenarioorchestrator/verify.go
@@ -11,10 +11,11 @@ import (
 	"github.com/krkn-chaos/krknctl/pkg/verify"
 )
 
-// ProgressPauser, when set by the CLI layer, is invoked immediately before any
-// verification result (verified, rejected, or the --run-unsigned-images bypass
-// warning) is written to stderr, and must return a resume callback that is
-// invoked once the message has been printed. It lets the run path stop an active
+// ProgressPauser is an optional hook that, when set by the CLI layer, is
+// invoked immediately before any verification result (verified, rejected, or
+// the --run-unsigned-images bypass warning) is written to stderr, and must
+// return a resume callback that is invoked once the message has been printed.
+// It lets the run path stop an active
 // progress spinner so the full-width verification messages are not overwritten
 // or interleaved with the spinner frame, without coupling this package to a
 // concrete spinner implementation.


### PR DESCRIPTION
## What

Signature-verification messages (verified / rejected / `--run-unsigned-images` bypass warning) were being appended to the running progress spinner frame, so they rendered on a dirty, interleaved line.

## How

- Add a `ProgressPauser` hook in `pkg/scenarioorchestrator` that the CLI layer can register. It is invoked right before a verification result is written to stderr and returns a resume callback invoked afterwards.
- `cmd/run.go` wires it to stop/start the spinner, but only when the spinner is actually active (`spinner.Active()`), and resets the hook via `defer`.
- The hook is left `nil` on paths with no spinner (graph runs, tests), where `pauseProgress()` is a safe no-op — so the orchestrator package stays decoupled from any concrete spinner implementation.

## Testing

- `go build -tags containers_image_openpgp ./...` — ok
- `go vet` on `cmd/...` and `pkg/scenarioorchestrator/...` — ok
- `go test ./pkg/scenarioorchestrator/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)