### PR TITLE
fix(release): generate changelog from commits

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${VERSION:?VERSION must be set}"
+OUTPUT=${OUTPUT:-release-notes.md}
+TEMPLATE=${TEMPLATE:-.github/release-template.md}
+
+previous_tag=$(git describe --first-parent --tags --match 'v*' --exclude "${VERSION}" --abbrev=0 "${VERSION}" 2>/dev/null || true)
+
+if [[ -n "${previous_tag}" ]]; then
+	changes=$(git log --no-merges --pretty=format:'- %s (%h)' "${previous_tag}..${VERSION}")
+else
+	changes=$(git log --no-merges --pretty=format:'- %s (%h)' "${VERSION}")
+fi
+
+if [[ -z "${changes}" ]]; then
+	changes='- No changes recorded.'
+fi
+
+VERSION="${VERSION}" CHANGES="${changes}" perl -0pe \
+	's/\{VERSION\}/$ENV{VERSION}/g; s/\{CHANGES\}/$ENV{CHANGES}/g' \
+	"${TEMPLATE}" > "${OUTPUT}"

--- a/.github/scripts/generate-release-notes_test.sh
+++ b/.github/scripts/generate-release-notes_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT
+
+git_config() {
+	git -C "${work_dir}" config user.email test@example.com
+	git -C "${work_dir}" config user.name test
+	git -C "${work_dir}" config commit.gpgsign false
+}
+
+commit() {
+	local message=$1
+	echo "${message}" >> "${work_dir}/history.txt"
+	git -C "${work_dir}" add history.txt
+	git -C "${work_dir}" commit -m "${message}" >/dev/null
+}
+
+assert_contains() {
+	local value=$1
+	local expected=$2
+	if [[ "${value}" != *"${expected}"* ]]; then
+		echo "expected output to contain: ${expected}" >&2
+		exit 1
+	fi
+}
+
+git -C "${work_dir}" init -q
+git_config
+commit "first release"
+git -C "${work_dir}" tag v1.0.0
+commit "feature after release"
+git -C "${work_dir}" tag internal-checkpoint
+commit "fix after non-release tag"
+git -C "${work_dir}" tag v1.1.0
+
+cat > "${work_dir}/template.md" <<'EOF'
+# {VERSION}
+
+{CHANGES}
+EOF
+
+(cd "${work_dir}" && VERSION=v1.1.0 OUTPUT="${work_dir}/notes.md" TEMPLATE="${work_dir}/template.md" \
+	bash "${script_dir}/generate-release-notes.sh")
+notes=$(<"${work_dir}/notes.md")
+assert_contains "${notes}" '# v1.1.0'
+assert_contains "${notes}" 'feature after release'
+assert_contains "${notes}" 'fix after non-release tag'
+
+git -C "${work_dir}" tag v1.2.0
+(cd "${work_dir}" && VERSION=v1.2.0 OUTPUT="${work_dir}/empty.md" TEMPLATE="${work_dir}/template.md" \
+	bash "${script_dir}/generate-release-notes.sh")
+assert_contains "$(<"${work_dir}/empty.md")" '- No changes recorded.'
+
+first_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}" "${first_dir}"' EXIT
+git -C "${first_dir}" init -q
+git -C "${first_dir}" config user.email test@example.com
+git -C "${first_dir}" config user.name test
+git -C "${first_dir}" config commit.gpgsign false
+echo first > "${first_dir}/history.txt"
+git -C "${first_dir}" add history.txt
+git -C "${first_dir}" commit -m 'first-ever release' >/dev/null
+git -C "${first_dir}" tag v0.1.0
+(cd "${first_dir}" && VERSION=v0.1.0 OUTPUT="${first_dir}/notes.md" TEMPLATE="${work_dir}/template.md" \
+	bash "${script_dir}/generate-release-notes.sh")
+assert_contains "$(<"${first_dir}/notes.md")" 'first-ever release'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,27 +13,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: test release note generation
+        run: bash .github/scripts/generate-release-notes_test.sh
       - name: generate release notes from commits
         run: |
-          VERSION="$GITHUB_REF_NAME"
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || true)
-
-          if [ -n "$PREVIOUS_TAG" ]; then
-            echo "Generating changes from $PREVIOUS_TAG to $VERSION"
-            CHANGES=$(git log --no-merges --pretty=format:'- %s (%h)' "${PREVIOUS_TAG}..${VERSION}")
-          else
-            echo "No previous tag found; generating changes from $VERSION"
-            CHANGES=$(git log --no-merges --pretty=format:'- %s (%h)' "$VERSION")
-          fi
-
-          if [ -z "$CHANGES" ]; then
-            CHANGES="- No changes recorded."
-          fi
-
-          VERSION="$VERSION" CHANGES="$CHANGES" perl -0pe \
-            's/\{VERSION\}/$ENV{VERSION}/g; s/\{CHANGES\}/$ENV{CHANGES}/g' \
-            .github/release-template.md > release-notes.md
-
+          VERSION="$GITHUB_REF_NAME" \
+            OUTPUT=release-notes.md \
+            TEMPLATE=.github/release-template.md \
+            bash .github/scripts/generate-release-notes.sh
           cat release-notes.md
       - name: create release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,45 +10,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: calculate previous tag
+        with:
+          fetch-depth: 0
+
+      - name: generate release notes from commits
         run: |
-          git fetch --tags origin
-          PREVIOUS_TAG=$(git tag --sort=-creatordate | sed -n '2 p')
-          echo $PREVIOUS_TAG 
-          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> "$GITHUB_ENV"
+          VERSION="$GITHUB_REF_NAME"
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || true)
 
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "Generating changes from $PREVIOUS_TAG to $VERSION"
+            CHANGES=$(git log --no-merges --pretty=format:'- %s (%h)' "${PREVIOUS_TAG}..${VERSION}")
+          else
+            echo "No previous tag found; generating changes from $VERSION"
+            CHANGES=$(git log --no-merges --pretty=format:'- %s (%h)' "$VERSION")
+          fi
 
+          if [ -z "$CHANGES" ]; then
+            CHANGES="- No changes recorded."
+          fi
 
-      - name: generate release notes from template
-        id: release-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: |
-          NOTES=$(gh api \
-          --method POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/krkn-chaos/krknctl/releases/generate-notes \
-          -f "tag_name=${{ github.ref_name }}" -f "target_commitish=main" -f "previous_tag_name=${{ env.PREVIOUS_TAG }}" | jq -r .body)
-          echo "NOTES<<EOF" >> $GITHUB_ENV
-          echo "$NOTES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          VERSION="$VERSION" CHANGES="$CHANGES" perl -0pe \
+            's/\{VERSION\}/$ENV{VERSION}/g; s/\{CHANGES\}/$ENV{CHANGES}/g' \
+            .github/release-template.md > release-notes.md
 
-      - name: replace placeholders in template
-        run: |
-          
-          echo "${{ env.NOTES }}"
-          TEMPLATE=$(cat .github/release-template.md)
-          VERSION=${{ github.ref_name }}
-          NOTES="${{ env.NOTES }}"
-          OUTPUT=${TEMPLATE//\{VERSION\}/$VERSION}
-          OUTPUT=${OUTPUT//\{CHANGES\}/$NOTES}
-          echo "$OUTPUT" > release-notes.md
+          cat release-notes.md
       - name: create release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}"  -F release-notes.md
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --notes-file release-notes.md
 
       - name: Install Syft
         run: |


### PR DESCRIPTION
## Summary
- preserve the existing `.github/release-template.md` and artifact links
- replace label/PR-based GitHub release-note generation with a commit list from the previous tag
- handle the first release and verify the pushed tag before creating the release
- keep SBOM generation and upload unchanged

## Validation
- workflow YAML parsed successfully with yq
- template remains unchanged
- local smoke test generated the Changes section from `v0.14.0-beta..v0.14.1-beta`
- `git diff --check` passed

Refs: tsebastiani-90fz