### PR TITLE
fix(provider): populate authoritative image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,19 @@ Its primary objective is to streamline the usage of `krkn` by providing features
 and much more, effectively abstracting the complexities of the container environment. 
 This allows users to focus solely on implementing chaos engineering practices without worrying about runtime complexities.
 
+### Listing available scenarios
+
+`krknctl list available` displays the image size and signature status for each
+scenario. The `Signature` column reports one of:
+
+- `signed`: a trusted signature was verified;
+- `unsigned`: no signature was found;
+- `untrusted`: signatures were found but none matched a trusted key;
+- `unknown`: verification could not be completed.
+
 <br/>
 
 
 ## Documentation:
 
 Instructions on how to setup, configure and run Kraken can be found in the [documentation](https://krkn-chaos.dev/docs/krknctl/).
-

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -58,9 +58,13 @@ func NewListScenariosCommand(factory *providerfactory.ProviderFactory, config co
 				log.Fatalf("failed to fetch scenarios: %v", err)
 			}
 			s.Stop()
+			signatureSpinner := NewSpinnerWithSuffix("🔒 verifying image signatures...")
+			signatureSpinner.Start()
 			if err := PopulateScenarioSignatureStatuses(cmd.Context(), provider, registrySettings, scenarios); err != nil {
+				signatureSpinner.Stop()
 				return err
 			}
+			signatureSpinner.Stop()
 			scenarioTable := NewScenarioTable(scenarios, privateRegistry)
 			scenarioTable.Print()
 			fmt.Print("\n")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -58,6 +58,9 @@ func NewListScenariosCommand(factory *providerfactory.ProviderFactory, config co
 				log.Fatalf("failed to fetch scenarios: %v", err)
 			}
 			s.Stop()
+			if err := PopulateScenarioSignatureStatuses(cmd.Context(), provider, registrySettings, scenarios); err != nil {
+				return err
+			}
 			scenarioTable := NewScenarioTable(scenarios, privateRegistry)
 			scenarioTable.Print()
 			fmt.Print("\n")

--- a/cmd/signatures.go
+++ b/cmd/signatures.go
@@ -2,61 +2,21 @@ package cmd
 
 import (
 	"context"
-	"sync"
 
 	"github.com/krkn-chaos/krknctl/pkg/provider"
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
-	"github.com/krkn-chaos/krknctl/pkg/verify"
 )
-
-const signatureWorkers = 8
 
 // PopulateScenarioSignatureStatuses verifies the signature status of every
 // listed scenario. Verification failures are represented as unknown so one
 // unavailable registry entry does not hide the rest of the listing.
 func PopulateScenarioSignatureStatuses(ctx context.Context, dataProvider provider.ScenarioDataProvider, registry *models.RegistryV2, scenarios *[]models.ScenarioTag) error {
-	if len(*scenarios) == 0 {
-		return nil
+	statuses, err := provider.VerifyImageSignatures(ctx, dataProvider, registry, *scenarios)
+	if err != nil {
+		return err
 	}
-
-	workerCount := signatureWorkers
-	if len(*scenarios) < workerCount {
-		workerCount = len(*scenarios)
+	for i, status := range statuses {
+		(*scenarios)[i].SignatureStatus = string(status)
 	}
-	jobs := make(chan int)
-	var workers sync.WaitGroup
-	workers.Add(workerCount)
-	for range workerCount {
-		go func() {
-			defer workers.Done()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case index, ok := <-jobs:
-					if !ok {
-						return
-					}
-					status, err := dataProvider.GetImageSignatureStatus(ctx, registry, (*scenarios)[index])
-					if err != nil || status == "" {
-						status = verify.SignatureUnknown
-					}
-					(*scenarios)[index].SignatureStatus = string(status)
-				}
-			}
-		}()
-	}
-
-	for index := range *scenarios {
-		select {
-		case <-ctx.Done():
-			close(jobs)
-			workers.Wait()
-			return ctx.Err()
-		case jobs <- index:
-		}
-	}
-	close(jobs)
-	workers.Wait()
-	return ctx.Err()
+	return nil
 }

--- a/cmd/signatures.go
+++ b/cmd/signatures.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+
+	"github.com/krkn-chaos/krknctl/pkg/provider"
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/krkn-chaos/krknctl/pkg/verify"
+)
+
+const signatureWorkers = 8
+
+// PopulateScenarioSignatureStatuses verifies the signature status of every
+// listed scenario. Verification failures are represented as unknown so one
+// unavailable registry entry does not hide the rest of the listing.
+func PopulateScenarioSignatureStatuses(ctx context.Context, dataProvider provider.ScenarioDataProvider, registry *models.RegistryV2, scenarios *[]models.ScenarioTag) error {
+	if len(*scenarios) == 0 {
+		return nil
+	}
+
+	workerCount := signatureWorkers
+	if len(*scenarios) < workerCount {
+		workerCount = len(*scenarios)
+	}
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case index, ok := <-jobs:
+					if !ok {
+						return
+					}
+					status, err := dataProvider.GetImageSignatureStatus(ctx, registry, (*scenarios)[index])
+					if err != nil || status == "" {
+						status = verify.SignatureUnknown
+					}
+					(*scenarios)[index].SignatureStatus = string(status)
+				}
+			}
+		}()
+	}
+
+	for index := range *scenarios {
+		select {
+		case <-ctx.Done():
+			close(jobs)
+			workers.Wait()
+			return ctx.Err()
+		case jobs <- index:
+		}
+	}
+	close(jobs)
+	workers.Wait()
+	return ctx.Err()
+}

--- a/cmd/signatures_test.go
+++ b/cmd/signatures_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/krkn-chaos/krknctl/pkg/provider"
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/krkn-chaos/krknctl/pkg/verify"
+	"github.com/stretchr/testify/require"
+)
+
+type signatureStatusProvider struct {
+	statuses map[string]verify.SignatureStatus
+}
+
+func (p signatureStatusProvider) GetRegistryImages(*models.RegistryV2) (*[]models.ScenarioTag, error) {
+	return nil, nil
+}
+
+func (p signatureStatusProvider) GetGlobalEnvironment(*models.RegistryV2, string) (*models.ScenarioDetail, error) {
+	return nil, nil
+}
+
+func (p signatureStatusProvider) GetScenarioDetail(string, *models.RegistryV2) (*models.ScenarioDetail, error) {
+	return nil, nil
+}
+
+func (p signatureStatusProvider) GetImageSignatureStatus(_ context.Context, _ *models.RegistryV2, tag models.ScenarioTag) (verify.SignatureStatus, error) {
+	status, ok := p.statuses[tag.Name]
+	if !ok {
+		return verify.SignatureUnknown, errors.New("verification failed")
+	}
+	return status, nil
+}
+
+func (p signatureStatusProvider) ScaffoldScenarios([]string, bool, *models.RegistryV2, bool, *provider.ScaffoldSeed) (*string, error) {
+	return nil, nil
+}
+
+func TestPopulateScenarioSignatureStatuses(t *testing.T) {
+	scenarios := []models.ScenarioTag{{Name: "signed"}, {Name: "unsigned"}, {Name: "unknown"}}
+	dataProvider := signatureStatusProvider{statuses: map[string]verify.SignatureStatus{
+		"signed":   verify.SignatureSigned,
+		"unsigned": verify.SignatureUnsigned,
+	}}
+
+	require.NoError(t, PopulateScenarioSignatureStatuses(context.Background(), dataProvider, nil, &scenarios))
+	require.Equal(t, "signed", scenarios[0].SignatureStatus)
+	require.Equal(t, "unsigned", scenarios[1].SignatureStatus)
+	require.Equal(t, "unknown", scenarios[2].SignatureStatus)
+}

--- a/cmd/signatures_test.go
+++ b/cmd/signatures_test.go
@@ -51,3 +51,12 @@ func TestPopulateScenarioSignatureStatuses(t *testing.T) {
 	require.Equal(t, "unsigned", scenarios[1].SignatureStatus)
 	require.Equal(t, "unknown", scenarios[2].SignatureStatus)
 }
+
+func TestPopulateScenarioSignatureStatusesReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	scenarios := []models.ScenarioTag{{Name: "scenario"}}
+
+	err := PopulateScenarioSignatureStatuses(ctx, signatureStatusProvider{}, nil, &scenarios)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/cmd/tables.go
+++ b/cmd/tables.go
@@ -12,6 +12,7 @@ import (
 	orchestratormodels "github.com/krkn-chaos/krknctl/pkg/scenarioorchestrator/models"
 	"github.com/krkn-chaos/krknctl/pkg/scenarioorchestrator/utils"
 	"github.com/krkn-chaos/krknctl/pkg/typing"
+	"github.com/krkn-chaos/krknctl/pkg/verify"
 )
 import "github.com/rodaine/table"
 
@@ -21,17 +22,21 @@ var columnFmt = color.New(color.FgYellow).SprintfFunc()
 func NewScenarioTable(scenarios *[]models.ScenarioTag, private bool) table.Table {
 	var tbl table.Table
 	if private {
-		tbl = table.New("Name")
+		tbl = table.New("Name", "Signature")
 	} else {
-		tbl = table.New("Name", "Size", "Digest", "Last Modified")
+		tbl = table.New("Name", "Size", "Digest", "Last Modified", "Signature")
 	}
 
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 	for _, scenario := range *scenarios {
+		signatureStatus := scenario.SignatureStatus
+		if signatureStatus == "" {
+			signatureStatus = string(verify.SignatureUnknown)
+		}
 		if private {
-			tbl.AddRow(scenario.Name)
+			tbl.AddRow(scenario.Name, signatureStatus)
 		} else {
-			tbl.AddRow(scenario.Name, *scenario.Size, *scenario.Digest, *scenario.LastModified)
+			tbl.AddRow(scenario.Name, *scenario.Size, *scenario.Digest, *scenario.LastModified, signatureStatus)
 		}
 
 	}

--- a/cmd/tables.go
+++ b/cmd/tables.go
@@ -36,7 +36,19 @@ func NewScenarioTable(scenarios *[]models.ScenarioTag, private bool) table.Table
 		if private {
 			tbl.AddRow(scenario.Name, signatureStatus)
 		} else {
-			tbl.AddRow(scenario.Name, *scenario.Size, *scenario.Digest, *scenario.LastModified, signatureStatus)
+			size := "unknown"
+			if scenario.Size != nil {
+				size = fmt.Sprintf("%d", *scenario.Size)
+			}
+			digest := "unknown"
+			if scenario.Digest != nil {
+				digest = *scenario.Digest
+			}
+			lastModified := "unknown"
+			if scenario.LastModified != nil {
+				lastModified = scenario.LastModified.Format(time.RFC3339)
+			}
+			tbl.AddRow(scenario.Name, size, digest, lastModified, signatureStatus)
 		}
 
 	}

--- a/cmd/tables.go
+++ b/cmd/tables.go
@@ -19,6 +19,21 @@ import "github.com/rodaine/table"
 var headerFmt = color.New(color.FgGreen, color.Underline).SprintfFunc()
 var columnFmt = color.New(color.FgYellow).SprintfFunc()
 
+func humanReadableBytes(size int64) string {
+	if size < 1024 {
+		return fmt.Sprintf("%d B", size)
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	value := float64(size)
+	for _, unit := range units {
+		value /= 1024
+		if value < 1024 || unit == units[len(units)-1] {
+			return fmt.Sprintf("%.2f %s", value, unit)
+		}
+	}
+	return fmt.Sprintf("%d B", size)
+}
+
 func NewScenarioTable(scenarios *[]models.ScenarioTag, private bool) table.Table {
 	var tbl table.Table
 	if private {
@@ -38,7 +53,7 @@ func NewScenarioTable(scenarios *[]models.ScenarioTag, private bool) table.Table
 		} else {
 			size := "unknown"
 			if scenario.Size != nil {
-				size = fmt.Sprintf("%d", *scenario.Size)
+				size = humanReadableBytes(*scenario.Size)
 			}
 			digest := "unknown"
 			if scenario.Digest != nil {

--- a/cmd/tables_test.go
+++ b/cmd/tables_test.go
@@ -104,3 +104,8 @@ func TestNewScenarioTable_AllowsMissingMetadata(t *testing.T) {
 	table := NewScenarioTable(&scenarios, false)
 	assert.NotNil(t, table)
 }
+
+func TestHumanReadableBytes(t *testing.T) {
+	assert.Equal(t, "6.03 KiB", humanReadableBytes(6179))
+	assert.Equal(t, "5.00 MiB", humanReadableBytes(5*1024*1024))
+}

--- a/cmd/tables_test.go
+++ b/cmd/tables_test.go
@@ -1,97 +1,15 @@
 package cmd
 
 import (
-	"bytes"
-	"fmt"
-	"github.com/stretchr/testify/assert"
-	"io"
 	"testing"
+
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewEnvironmentTable(t *testing.T) {
-	config := getConfig(t)
-	longString := "lkaslakslakslakslakslakslakslaksalsklaskaskl"
-	values := map[string]ParsedField{"value": {longString, false}}
-	var buf bytes.Buffer
-	writer := io.Writer(&buf)
-	table := NewEnvironmentTable(values, config)
-	table = table.WithWriter(writer)
-	table.Print()
-	assert.NotNil(t, buf)
-	stringBuffer := buf.String()
-	assert.Contains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
+func TestNewScenarioTable_AllowsMissingMetadata(t *testing.T) {
+	scenarios := []models.ScenarioTag{{Name: "scenario-without-metadata"}}
 
-	buf.Reset()
-	shortString := longString[0:config.TableFieldMaxLength]
-	values = map[string]ParsedField{"value": {shortString, false}}
-	table = NewEnvironmentTable(values, config)
-	table = table.WithWriter(writer)
-	table.Print()
-	assert.NotNil(t, buf)
-	stringBuffer = buf.String()
-	assert.NotContains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
-	assert.Contains(t, stringBuffer, shortString)
-}
-
-func TestNewGraphTable(t *testing.T) {
-	graph := [][]string{
-		{
-			"application-outages-test-1",
-			"application-outages-test-2",
-			"application-outages-test-3",
-			"application-outages-test-4",
-			"application-outages-test-5",
-			"application-outages-test-6",
-		},
-		{
-			"node-cpu-hog-test-1",
-			"node-cpu-hog-test-2",
-			"node-cpu-hog-test-3",
-			"node-cpu-hog-test-4",
-			"node-cpu-hog-test-5",
-			"node-cpu-hog-test-6",
-			"node-cpu-hog-test-7",
-			"node-cpu-hog-test-8",
-		},
-		{
-			"do-not-exist-node-cpu-hog-test-1",
-			"do-not-exist-node-cpu-hog-test-2",
-			"do-not-exist-node-cpu-hog-test-3",
-			"do-not-exist-node-cpu-hog-test-4",
-			"do-not-exist-node-cpu-hog-test-5",
-			"do-not-exist-node-cpu-hog-test-6",
-			"do-not-exist-node-cpu-hog-test-7",
-			"do-not-exist-node-cpu-hog-test-8",
-			"example-1",
-			"example-2",
-		},
-
-		{
-			"affected",
-			"africa",
-			"alternative",
-			"alone",
-			"alias",
-			"afraid",
-			"although",
-			"always",
-		},
-	}
-
-	config := getConfig(t)
-
-	table, err := NewGraphTable(graph, config)
-	assert.Nil(t, err)
-	var buf bytes.Buffer
-	writer := io.Writer(&buf)
-	table = table.WithWriter(writer)
-	table.Print()
-	assert.NotNil(t, buf)
-	stringBuffer := buf.String()
-	assert.Contains(t, stringBuffer, "(8) node-cpu-hog-test")
-	assert.Contains(t, stringBuffer, "(8) do-not-exist-node-cpu-hog-test")
-	assert.Contains(t, stringBuffer, "(2) example")
-	assert.Contains(t, stringBuffer, "(3) af")
-	assert.Contains(t, stringBuffer, "(5) a")
-
+	table := NewScenarioTable(&scenarios, false)
+	require.NotNil(t, table)
 }

--- a/cmd/tables_test.go
+++ b/cmd/tables_test.go
@@ -1,15 +1,106 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io"
 	"testing"
 
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
-	"github.com/stretchr/testify/require"
 )
+
+func TestNewEnvironmentTable(t *testing.T) {
+	config := getConfig(t)
+	longString := "lkaslakslakslakslakslakslakslaksalsklaskaskl"
+	values := map[string]ParsedField{"value": {longString, false}}
+	var buf bytes.Buffer
+	writer := io.Writer(&buf)
+	table := NewEnvironmentTable(values, config)
+	table = table.WithWriter(writer)
+	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer := buf.String()
+	assert.Contains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
+
+	buf.Reset()
+	shortString := longString[0:config.TableFieldMaxLength]
+	values = map[string]ParsedField{"value": {shortString, false}}
+	table = NewEnvironmentTable(values, config)
+	table = table.WithWriter(writer)
+	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer = buf.String()
+	assert.NotContains(t, stringBuffer, fmt.Sprintf("%s...(%d bytes more)", longString[0:config.TableFieldMaxLength], len(longString)-config.TableFieldMaxLength))
+	assert.Contains(t, stringBuffer, shortString)
+}
+
+func TestNewGraphTable(t *testing.T) {
+	graph := [][]string{
+		{
+			"application-outages-test-1",
+			"application-outages-test-2",
+			"application-outages-test-3",
+			"application-outages-test-4",
+			"application-outages-test-5",
+			"application-outages-test-6",
+		},
+		{
+			"node-cpu-hog-test-1",
+			"node-cpu-hog-test-2",
+			"node-cpu-hog-test-3",
+			"node-cpu-hog-test-4",
+			"node-cpu-hog-test-5",
+			"node-cpu-hog-test-6",
+			"node-cpu-hog-test-7",
+			"node-cpu-hog-test-8",
+		},
+		{
+			"do-not-exist-node-cpu-hog-test-1",
+			"do-not-exist-node-cpu-hog-test-2",
+			"do-not-exist-node-cpu-hog-test-3",
+			"do-not-exist-node-cpu-hog-test-4",
+			"do-not-exist-node-cpu-hog-test-5",
+			"do-not-exist-node-cpu-hog-test-6",
+			"do-not-exist-node-cpu-hog-test-7",
+			"do-not-exist-node-cpu-hog-test-8",
+			"example-1",
+			"example-2",
+		},
+
+		{
+			"affected",
+			"africa",
+			"alternative",
+			"alone",
+			"alias",
+			"afraid",
+			"although",
+			"always",
+		},
+	}
+
+	config := getConfig(t)
+
+	table, err := NewGraphTable(graph, config)
+	assert.Nil(t, err)
+	var buf bytes.Buffer
+	writer := io.Writer(&buf)
+	table = table.WithWriter(writer)
+	table.Print()
+	assert.NotNil(t, buf)
+	stringBuffer := buf.String()
+	assert.Contains(t, stringBuffer, "(8) node-cpu-hog-test")
+	assert.Contains(t, stringBuffer, "(8) do-not-exist-node-cpu-hog-test")
+	assert.Contains(t, stringBuffer, "(2) example")
+	assert.Contains(t, stringBuffer, "(3) af")
+	assert.Contains(t, stringBuffer, "(5) a")
+
+}
 
 func TestNewScenarioTable_AllowsMissingMetadata(t *testing.T) {
 	scenarios := []models.ScenarioTag{{Name: "scenario-without-metadata"}}
 
 	table := NewScenarioTable(&scenarios, false)
-	require.NotNil(t, table)
+	assert.NotNil(t, table)
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -62,7 +62,8 @@ func TestGetProvider(t *testing.T) {
 	scenario, err = privateProvider.GetScenarioDetail("dummy-scenario", &pr)
 	assert.Nil(t, err)
 	assert.NotNil(t, scenario)
-	assert.Nil(t, scenario.Size)
+	assert.NotNil(t, scenario.Size)
+	assert.Greater(t, *scenario.Size, int64(0))
 
 }
 

--- a/pkg/provider/models/models.go
+++ b/pkg/provider/models/models.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/registry"
@@ -23,6 +25,23 @@ type RegistryV2 struct {
 	ScenarioRepository string  `form:"scenario_repository"`
 	SkipTLS            bool    `form:"skip_tls"`
 	Insecure           bool    `form:"insecure"`
+	// Platform identifies the Linux container platform to resolve from a
+	// multi-platform image index. When empty, linux/<host architecture> is
+	// used because scenario images run in Linux containers.
+	Platform string `form:"platform" json:"platform,omitempty"`
+}
+
+// GetPlatform returns the platform used when resolving a multi-platform image.
+func (r *RegistryV2) GetPlatform() string {
+	if r.Platform != "" {
+		return r.Platform
+	}
+	return "linux/" + runtime.GOARCH
+}
+
+// HasPlatform reports whether platform is the configured target platform.
+func (r *RegistryV2) HasPlatform(platform string) bool {
+	return strings.EqualFold(r.GetPlatform(), platform)
 }
 
 func NewRegistryV2FromEnv(config config.Config) (*RegistryV2, error) {

--- a/pkg/provider/models/models.go
+++ b/pkg/provider/models/models.go
@@ -33,7 +33,7 @@ type RegistryV2 struct {
 
 // GetPlatform returns the platform used when resolving a multi-platform image.
 func (r *RegistryV2) GetPlatform() string {
-	if r.Platform != "" {
+	if isSupportedLinuxPlatform(r.Platform) {
 		return r.Platform
 	}
 	return "linux/" + runtime.GOARCH
@@ -41,7 +41,42 @@ func (r *RegistryV2) GetPlatform() string {
 
 // HasPlatform reports whether platform is the configured target platform.
 func (r *RegistryV2) HasPlatform(platform string) bool {
-	return strings.EqualFold(r.GetPlatform(), platform)
+	parts := strings.Split(platform, "/")
+	if len(parts) < 2 || len(parts) > 3 {
+		return false
+	}
+	variant := ""
+	if len(parts) == 3 {
+		variant = parts[2]
+	}
+	return r.MatchesPlatform(parts[0], parts[1], variant)
+}
+
+// MatchesPlatform reports whether a manifest platform matches the configured
+// Linux target. An unqualified target architecture accepts any variant of the
+// architecture; a configured variant requires an exact match.
+func (r *RegistryV2) MatchesPlatform(osName, architecture, variant string) bool {
+	if !strings.EqualFold(osName, "linux") {
+		return false
+	}
+	target := strings.Split(r.GetPlatform(), "/")
+	if !strings.EqualFold(target[1], architecture) {
+		return false
+	}
+	return len(target) == 2 || strings.EqualFold(target[2], variant)
+}
+
+func isSupportedLinuxPlatform(platform string) bool {
+	parts := strings.Split(platform, "/")
+	if len(parts) < 2 || len(parts) > 3 || !strings.EqualFold(parts[0], "linux") || parts[1] == "" {
+		return false
+	}
+	switch strings.ToLower(parts[1]) {
+	case "386", "amd64", "arm", "arm64", "ppc64le", "riscv64", "s390x":
+	default:
+		return false
+	}
+	return len(parts) == 2 || parts[2] != ""
 }
 
 func NewRegistryV2FromEnv(config config.Config) (*RegistryV2, error) {

--- a/pkg/provider/models/models_test.go
+++ b/pkg/provider/models/models_test.go
@@ -206,3 +206,21 @@ func TestNewRegistryV2FromEnv(t *testing.T) {
 	assert.Nil(t, registryv2)
 
 }
+
+func TestRegistryV2PlatformValidation(t *testing.T) {
+	registry := RegistryV2{Platform: "linux/arm64/v8"}
+	assert.Equal(t, "linux/arm64/v8", registry.GetPlatform())
+	assert.True(t, registry.MatchesPlatform("linux", "arm64", "v8"))
+	assert.False(t, registry.MatchesPlatform("windows", "arm64", "v8"))
+	assert.False(t, registry.MatchesPlatform("linux", "amd64", ""))
+
+	registry.Platform = "windows/amd64"
+	assert.NotEqual(t, "windows/amd64", registry.GetPlatform())
+	assert.True(t, registry.HasPlatform(registry.GetPlatform()))
+}
+
+func TestRegistryV2UnqualifiedPlatformAcceptsVariant(t *testing.T) {
+	registry := RegistryV2{Platform: "linux/arm64"}
+	assert.True(t, registry.MatchesPlatform("linux", "arm64", "v8"))
+	assert.True(t, registry.MatchesPlatform("linux", "arm64", ""))
+}

--- a/pkg/provider/quay/models.go
+++ b/pkg/provider/quay/models.go
@@ -3,6 +3,7 @@ package quay
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -79,6 +80,25 @@ func (q ManifestList) GetFirstAvailableManifest() *ManifestEntry {
 		}
 	}
 	return nil
+}
+
+// GetKrknctlManifest selects the manifest matching krknctl's architecture and
+// falls back to the first usable descriptor when no exact match exists.
+func (q ManifestList) GetKrknctlManifest() *ManifestEntry {
+	var first *ManifestEntry
+	for i := range q.Manifests {
+		manifest := &q.Manifests[i]
+		if manifest.Digest == "" {
+			continue
+		}
+		if first == nil {
+			first = manifest
+		}
+		if manifest.Platform.Architecture == runtime.GOARCH {
+			return manifest
+		}
+	}
+	return first
 }
 
 // ManifestEntry represents a single platform-specific manifest

--- a/pkg/provider/quay/models.go
+++ b/pkg/provider/quay/models.go
@@ -88,7 +88,7 @@ func (q ManifestList) GetKrknctlManifest() *ManifestEntry {
 	var first *ManifestEntry
 	for i := range q.Manifests {
 		manifest := &q.Manifests[i]
-		if manifest.Digest == "" {
+		if manifest.Digest == "" || (manifest.Platform.OS != "" && !strings.EqualFold(manifest.Platform.OS, "linux")) {
 			continue
 		}
 		if first == nil {

--- a/pkg/provider/quay/models_test.go
+++ b/pkg/provider/quay/models_test.go
@@ -19,6 +19,17 @@ func TestManifestList_GetKrknctlManifest_MatchesArchitecture(t *testing.T) {
 	assert.Equal(t, "sha256:matching", selected.Digest)
 }
 
+func TestManifestList_GetKrknctlManifest_SkipsWindows(t *testing.T) {
+	list := ManifestList{Manifests: []ManifestEntry{
+		{Digest: "sha256:windows", Platform: Platform{OS: "windows", Architecture: runtime.GOARCH}},
+		{Digest: "sha256:linux", Platform: Platform{OS: "linux", Architecture: "other-arch"}},
+	}}
+
+	selected := list.GetKrknctlManifest()
+	require.NotNil(t, selected)
+	assert.Equal(t, "sha256:linux", selected.Digest)
+}
+
 func TestManifestList_GetKrknctlManifest_FallsBackToFirstUsable(t *testing.T) {
 	list := ManifestList{Manifests: []ManifestEntry{
 		{Digest: "", Platform: Platform{Architecture: runtime.GOARCH}},
@@ -57,4 +68,12 @@ func TestManifestImageSize_UnknownForIncompleteLayers(t *testing.T) {
 	}}))
 	assert.Nil(t, manifestImageSize(Manifest{LayerCompressedSize: "not-a-number"}))
 	assert.Nil(t, manifestImageSize(Manifest{}))
+}
+
+func TestPreserveKnownImageSizeWhenManifestMetadataIsIncomplete(t *testing.T) {
+	existing := int64(6179)
+	assert.Equal(t, int64(6179), *preserveKnownImageSize(&existing, Manifest{}))
+
+	replacement := preserveKnownImageSize(&existing, Manifest{LayerCompressedSize: "8192"})
+	assert.Equal(t, int64(8192), *replacement)
 }

--- a/pkg/provider/quay/models_test.go
+++ b/pkg/provider/quay/models_test.go
@@ -1,0 +1,60 @@
+package quay
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestList_GetKrknctlManifest_MatchesArchitecture(t *testing.T) {
+	list := ManifestList{Manifests: []ManifestEntry{
+		{Digest: "sha256:other", Platform: Platform{Architecture: "other-arch"}},
+		{Digest: "sha256:matching", Platform: Platform{Architecture: runtime.GOARCH}},
+	}}
+
+	selected := list.GetKrknctlManifest()
+	require.NotNil(t, selected)
+	assert.Equal(t, "sha256:matching", selected.Digest)
+}
+
+func TestManifestList_GetKrknctlManifest_FallsBackToFirstUsable(t *testing.T) {
+	list := ManifestList{Manifests: []ManifestEntry{
+		{Digest: "", Platform: Platform{Architecture: runtime.GOARCH}},
+		{Digest: "sha256:first-usable", Platform: Platform{Architecture: "other-arch"}},
+		{Digest: "sha256:second-usable", Platform: Platform{Architecture: "another-arch"}},
+	}}
+
+	selected := list.GetKrknctlManifest()
+	require.NotNil(t, selected)
+	assert.Equal(t, "sha256:first-usable", selected.Digest)
+}
+
+func TestManifestList_GetKrknctlManifest_Empty(t *testing.T) {
+	assert.Nil(t, (ManifestList{}).GetKrknctlManifest())
+}
+
+func TestManifestImageSize_UsesAggregateSize(t *testing.T) {
+	size := manifestImageSize(Manifest{LayerCompressedSize: "5242880"})
+	require.NotNil(t, size)
+	assert.Equal(t, int64(5242880), *size)
+}
+
+func TestManifestImageSize_SumsLayersWhenAggregateMissing(t *testing.T) {
+	size := manifestImageSize(Manifest{Layers: []Layer{
+		{CompressedSize: 100},
+		{CompressedSize: 250},
+	}})
+	require.NotNil(t, size)
+	assert.Equal(t, int64(350), *size)
+}
+
+func TestManifestImageSize_UnknownForIncompleteLayers(t *testing.T) {
+	assert.Nil(t, manifestImageSize(Manifest{Layers: []Layer{
+		{CompressedSize: 100},
+		{CompressedSize: 0},
+	}}))
+	assert.Nil(t, manifestImageSize(Manifest{LayerCompressedSize: "not-a-number"}))
+	assert.Nil(t, manifestImageSize(Manifest{}))
+}

--- a/pkg/provider/quay/scenario_provider.go
+++ b/pkg/provider/quay/scenario_provider.go
@@ -92,31 +92,62 @@ func (p *ScenarioProvider) getTagSize(dataSource string, tag *models.ScenarioTag
 	if tag.Digest == nil || *tag.Digest == "" {
 		return nil
 	}
-	body, err := p.getScenarioBytes(dataSource, *tag.Digest)
+	manifest, err := p.getResolvedManifest(dataSource, *tag.Digest)
 	if err != nil {
 		return nil
 	}
+	return manifestImageSize(manifest)
+}
+
+func (p *ScenarioProvider) getResolvedManifest(dataSource string, digest string) (Manifest, error) {
+	body, err := p.getScenarioBytes(dataSource, digest)
+	if err != nil {
+		return Manifest{}, err
+	}
 	var manifest Manifest
 	if err := json.Unmarshal(body, &manifest); err != nil {
-		return nil
+		return Manifest{}, err
 	}
-	if manifest.IsManifestList {
-		var manifestList ManifestList
-		if err := json.Unmarshal([]byte(manifest.ManifestData), &manifestList); err != nil {
-			return nil
-		}
-		selected := manifestList.GetFirstAvailableManifest()
-		if selected == nil || selected.Size <= 0 {
-			return nil
-		}
-		size := int64(selected.Size)
-		return &size
+	if !manifest.IsManifestList {
+		return manifest, nil
 	}
+	if manifest.ManifestData == "" {
+		return Manifest{}, errors.New("manifest list contains no manifest data")
+	}
+	var manifestList ManifestList
+	if err := json.Unmarshal([]byte(manifest.ManifestData), &manifestList); err != nil {
+		return Manifest{}, err
+	}
+	selected := manifestList.GetKrknctlManifest()
+	if selected == nil {
+		return Manifest{}, errors.New("manifest list contains no usable image manifest")
+	}
+	selectedBody, err := p.getScenarioBytes(dataSource, selected.Digest)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if err := json.Unmarshal(selectedBody, &manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func manifestImageSize(manifest Manifest) *int64 {
 	if manifest.LayerCompressedSize != "" {
 		size, err := strconv.ParseInt(manifest.LayerCompressedSize, 10, 64)
 		if err == nil && size > 0 {
 			return &size
 		}
+	}
+	var size int64
+	for _, layer := range manifest.Layers {
+		if layer.CompressedSize <= 0 {
+			return nil
+		}
+		size += layer.CompressedSize
+	}
+	if size > 0 {
+		return &size
 	}
 	return nil
 }
@@ -186,57 +217,14 @@ func (p *ScenarioProvider) getScenarioBytes(dataSource string, scenarioDigest st
 func (p *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *models.ScenarioTag, isGlobalEnvironment bool) (*models.ScenarioDetail, error) {
 
 	scenarioDigest := ""
-	if ((*foundScenario).Digest) != nil {
-		scenarioDigest = *((*foundScenario).Digest)
+	if foundScenario.Digest != nil {
+		scenarioDigest = *foundScenario.Digest
 	}
-	bodyBytes, err := p.getScenarioBytes(dataSource, scenarioDigest)
+	manifest, err := p.getResolvedManifest(dataSource, scenarioDigest)
 	if err != nil {
 		return nil, err
 	}
-
-	var manifest Manifest
-	err = json.Unmarshal(bodyBytes, &manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	// if the manifest is a manifestList (multiarch image) image metadata
-	// will be fetched from the first available image in the registry
-	// keeps retrocompatibility with registries with no manifests
-
-	if manifest.IsManifestList {
-		if manifest.ManifestData == "" {
-			return nil, errors.New("scenario image is a manifest without data, " +
-				"impossible to fetch details")
-		}
-		var ml ManifestList
-		err = json.Unmarshal([]byte(manifest.ManifestData), &ml)
-		if err != nil {
-			return nil, err
-		}
-		imageManifest := ml.GetFirstAvailableManifest()
-		if imageManifest == nil {
-			return nil, errors.New("scenario image not found for target architecture")
-		}
-
-		// The manifest-list tag size is not the selected image size. Always use
-		// the platform-specific manifest descriptor, when available.
-		foundScenario.Size = nil
-		if imageManifest.Size > 0 {
-			imageSize := int64(imageManifest.Size)
-			foundScenario.Size = &imageSize
-		}
-
-		bodyBytes, err = p.getScenarioBytes(dataSource, imageManifest.Digest)
-		if err != nil {
-			return nil, err
-		}
-
-		err = json.Unmarshal(bodyBytes, &manifest)
-		if err != nil {
-			return nil, err
-		}
-	}
+	foundScenario.Size = manifestImageSize(manifest)
 
 	scenarioDetail := models.ScenarioDetail{
 		ScenarioTag: *foundScenario,

--- a/pkg/provider/quay/scenario_provider.go
+++ b/pkg/provider/quay/scenario_provider.go
@@ -174,9 +174,10 @@ func (p *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 			return nil, errors.New("scenario image not found for target architecture")
 		}
 
-		// The manifest-list tag has no aggregate size. Use the size associated
-		// with the selected platform-specific manifest descriptor instead.
-		if foundScenario.Size == nil || *foundScenario.Size == 0 {
+		// The manifest-list tag size is not the selected image size. Always use
+		// the platform-specific manifest descriptor, when available.
+		foundScenario.Size = nil
+		if imageManifest.Size > 0 {
 			imageSize := int64(imageManifest.Size)
 			foundScenario.Size = &imageSize
 		}

--- a/pkg/provider/quay/scenario_provider.go
+++ b/pkg/provider/quay/scenario_provider.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/krkn-chaos/krknctl/pkg/provider"
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
@@ -22,7 +24,7 @@ type ScenarioProvider struct {
 	provider.BaseScenarioProvider
 }
 
-func (p *ScenarioProvider) getRegistryImages(dataSource string) (*[]models.ScenarioTag, error) {
+func (p *ScenarioProvider) getRegistryImages(dataSource string, resolveSizes bool) (*[]models.ScenarioTag, error) {
 	tagBaseURL, err := url.Parse(dataSource + "/tag")
 	if err != nil {
 		return nil, err
@@ -72,15 +74,44 @@ func (p *ScenarioProvider) getRegistryImages(dataSource string) (*[]models.Scena
 			Size:         tag.Size,
 			Digest:       &tag.ManifestDigest,
 		}
-		if scenarioTag.Size == nil || *scenarioTag.Size == 0 {
-			if size := p.getTagSize(dataSource, &scenarioTag); size != nil {
-				scenarioTag.Size = size
-			}
-		}
 		scenarioTags = append(scenarioTags, scenarioTag)
+	}
+	if resolveSizes {
+		p.populateMissingTagSizes(dataSource, scenarioTags)
 	}
 
 	return &scenarioTags, deferErr
+}
+
+func (p *ScenarioProvider) populateMissingTagSizes(dataSource string, tags []models.ScenarioTag) {
+	const workerCount = 8
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	count := workerCount
+	if len(tags) < count {
+		count = len(tags)
+	}
+	for range count {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				if tags[index].Size != nil && *tags[index].Size > 0 {
+					continue
+				}
+				if size := p.getTagSize(dataSource, &tags[index]); size != nil {
+					tags[index].Size = size
+				}
+			}
+		}()
+	}
+	for index := range tags {
+		if tags[index].Size == nil || *tags[index].Size == 0 {
+			jobs <- index
+		}
+	}
+	close(jobs)
+	workers.Wait()
 }
 
 // getTagSize resolves a missing listing size from the image manifest. Quay's
@@ -152,13 +183,20 @@ func manifestImageSize(manifest Manifest) *int64 {
 	return nil
 }
 
+func preserveKnownImageSize(existing *int64, manifest Manifest) *int64 {
+	if imageSize := manifestImageSize(manifest); imageSize != nil {
+		return imageSize
+	}
+	return existing
+}
+
 func (p *ScenarioProvider) GetRegistryImages(*models.RegistryV2) (*[]models.ScenarioTag, error) {
 	dataSource, err := p.Config.GetQuayScenarioRepositoryAPIURI()
 	if err != nil {
 		return nil, err
 	}
 
-	scenarioTags, err := p.getRegistryImages(dataSource)
+	scenarioTags, err := p.getRegistryImages(dataSource, true)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +230,8 @@ func (p *ScenarioProvider) getScenarioBytes(dataSource string, scenarioDigest st
 	}
 	bodyBytes := p.Cache.Get(baseURL.String())
 	if len(bodyBytes) == 0 {
-		resp, err := http.Get(baseURL.String())
+		client := http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Get(baseURL.String())
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +263,7 @@ func (p *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	if err != nil {
 		return nil, err
 	}
-	foundScenario.Size = manifestImageSize(manifest)
+	foundScenario.Size = preserveKnownImageSize(foundScenario.Size, manifest)
 
 	scenarioDetail := models.ScenarioDetail{
 		ScenarioTag: *foundScenario,
@@ -290,7 +329,7 @@ func (p *ScenarioProvider) GetScenarioDetail(scenario string, registry *models.R
 	if err != nil {
 		return nil, err
 	}
-	scenarios, err := p.GetRegistryImages(registry)
+	scenarios, err := p.getRegistryImages(dataSource, false)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +356,7 @@ func (p *ScenarioProvider) GetGlobalEnvironment(registry *models.RegistryV2, sce
 		return nil, err
 	}
 	var foundScenario *models.ScenarioTag = nil
-	scenarios, err := p.getRegistryImages(dataSource)
+	scenarios, err := p.getRegistryImages(dataSource, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/quay/scenario_provider.go
+++ b/pkg/provider/quay/scenario_provider.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/krkn-chaos/krknctl/pkg/provider"
@@ -65,15 +66,59 @@ func (p *ScenarioProvider) getRegistryImages(dataSource string) (*[]models.Scena
 
 	var scenarioTags []models.ScenarioTag
 	for _, tag := range quayPage.Tags {
-		scenarioTags = append(scenarioTags, models.ScenarioTag{
+		scenarioTag := models.ScenarioTag{
 			Name:         tag.Name,
 			LastModified: &tag.LastModified,
 			Size:         tag.Size,
 			Digest:       &tag.ManifestDigest,
-		})
+		}
+		if scenarioTag.Size == nil || *scenarioTag.Size == 0 {
+			if size := p.getTagSize(dataSource, &scenarioTag); size != nil {
+				scenarioTag.Size = size
+			}
+		}
+		scenarioTags = append(scenarioTags, scenarioTag)
 	}
 
 	return &scenarioTags, deferErr
+}
+
+// getTagSize resolves a missing listing size from the image manifest. Quay's
+// tag endpoint does not provide an aggregate size for manifest lists, so the
+// selected platform descriptor is the authoritative value for multi-arch
+// images. Metadata lookup failures leave the size unknown without hiding the
+// tag from the listing.
+func (p *ScenarioProvider) getTagSize(dataSource string, tag *models.ScenarioTag) *int64 {
+	if tag.Digest == nil || *tag.Digest == "" {
+		return nil
+	}
+	body, err := p.getScenarioBytes(dataSource, *tag.Digest)
+	if err != nil {
+		return nil
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return nil
+	}
+	if manifest.IsManifestList {
+		var manifestList ManifestList
+		if err := json.Unmarshal([]byte(manifest.ManifestData), &manifestList); err != nil {
+			return nil
+		}
+		selected := manifestList.GetFirstAvailableManifest()
+		if selected == nil || selected.Size <= 0 {
+			return nil
+		}
+		size := int64(selected.Size)
+		return &size
+	}
+	if manifest.LayerCompressedSize != "" {
+		size, err := strconv.ParseInt(manifest.LayerCompressedSize, 10, 64)
+		if err == nil && size > 0 {
+			return &size
+		}
+	}
+	return nil
 }
 
 func (p *ScenarioProvider) GetRegistryImages(*models.RegistryV2) (*[]models.ScenarioTag, error) {

--- a/pkg/provider/quay/scenario_provider_test.go
+++ b/pkg/provider/quay/scenario_provider_test.go
@@ -74,14 +74,16 @@ func TestScenarioProvider_GetRegistryImages_ResolvesMissingManifestListSize(t *t
 	dataSource := "https://quay.example/api/v1/repository/krkn-hub-multiarch"
 	tagURL := dataSource + "/tag"
 	manifestURL := dataSource + "/manifest/sha256:index"
+	selectedManifestURL := dataSource + "/manifest/sha256:linux"
 	provider.Cache.Set(tagURL, []byte(`{"tags":[{"name":"multiarch","manifest_digest":"sha256:index","last_modified":"Mon, 02 Jan 2023 12:00:00 +0000"}]}`))
 	provider.Cache.Set(manifestURL, []byte(`{"is_manifest_list":true,"manifest_data":"{\"manifests\":[{\"digest\":\"sha256:linux\",\"size\":12345}]}"}`))
+	provider.Cache.Set(selectedManifestURL, []byte(`{"layers":[{"compressed_size":5242880,"created_datetime":"Mon, 02 Jan 2023 12:00:00 +0000"}]}`))
 
 	tags, err := provider.getRegistryImages(dataSource)
 	assert.NoError(t, err)
 	if assert.Len(t, *tags, 1) {
 		require.NotNil(t, (*tags)[0].Size)
-		assert.Equal(t, int64(12345), *(*tags)[0].Size)
+		assert.Equal(t, int64(5242880), *(*tags)[0].Size)
 	}
 }
 

--- a/pkg/provider/quay/scenario_provider_test.go
+++ b/pkg/provider/quay/scenario_provider_test.go
@@ -77,6 +77,7 @@ func TestQuayScenarioProvider_GetScenarioDetail(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, scenario)
 	assert.Equal(t, len(scenario.Fields), 5)
+	assert.NotNil(t, scenario.Size, "scenario detail must preserve the authoritative Quay image size")
 
 	scenario, err = provider.GetScenarioDetail("cpu-memory-notitle", nil)
 	assert.NotNil(t, err)

--- a/pkg/provider/quay/scenario_provider_test.go
+++ b/pkg/provider/quay/scenario_provider_test.go
@@ -79,7 +79,7 @@ func TestScenarioProvider_GetRegistryImages_ResolvesMissingManifestListSize(t *t
 	provider.Cache.Set(manifestURL, []byte(`{"is_manifest_list":true,"manifest_data":"{\"manifests\":[{\"digest\":\"sha256:linux\",\"size\":12345}]}"}`))
 	provider.Cache.Set(selectedManifestURL, []byte(`{"layers":[{"compressed_size":5242880,"created_datetime":"Mon, 02 Jan 2023 12:00:00 +0000"}]}`))
 
-	tags, err := provider.getRegistryImages(dataSource)
+	tags, err := provider.getRegistryImages(dataSource, true)
 	assert.NoError(t, err)
 	if assert.Len(t, *tags, 1) {
 		require.NotNil(t, (*tags)[0].Size)

--- a/pkg/provider/quay/scenario_provider_test.go
+++ b/pkg/provider/quay/scenario_provider_test.go
@@ -9,6 +9,7 @@ import (
 	providerinterface "github.com/krkn-chaos/krknctl/pkg/provider"
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
@@ -62,6 +63,26 @@ func TestScenarioProvider_GetRegistryImages(t *testing.T) {
 	_, err = wrongProvider.GetRegistryImages(nil)
 	assert.Error(t, err)
 
+}
+
+func TestScenarioProvider_GetRegistryImages_ResolvesMissingManifestListSize(t *testing.T) {
+	config := getConfig(t)
+	provider := ScenarioProvider{providerinterface.BaseScenarioProvider{
+		Config: config,
+		Cache:  cache.NewCache(),
+	}}
+	dataSource := "https://quay.example/api/v1/repository/krkn-hub-multiarch"
+	tagURL := dataSource + "/tag"
+	manifestURL := dataSource + "/manifest/sha256:index"
+	provider.Cache.Set(tagURL, []byte(`{"tags":[{"name":"multiarch","manifest_digest":"sha256:index","last_modified":"Mon, 02 Jan 2023 12:00:00 +0000"}]}`))
+	provider.Cache.Set(manifestURL, []byte(`{"is_manifest_list":true,"manifest_data":"{\"manifests\":[{\"digest\":\"sha256:linux\",\"size\":12345}]}"}`))
+
+	tags, err := provider.getRegistryImages(dataSource)
+	assert.NoError(t, err)
+	if assert.Len(t, *tags, 1) {
+		require.NotNil(t, (*tags)[0].Size)
+		assert.Equal(t, int64(12345), *(*tags)[0].Size)
+	}
 }
 
 func TestQuayScenarioProvider_GetScenarioDetail(t *testing.T) {

--- a/pkg/provider/registryv2/models.go
+++ b/pkg/provider/registryv2/models.go
@@ -16,14 +16,45 @@ type ManifestV2 struct {
 	Architecture  string              `json:"architecture"`
 	SchemaVersion int                 `json:"schemaVersion"`
 	RawLayers     []map[string]string `json:"history"`
-	Layers        []LayerV1Compat
-	Config        ManifestDescriptor `json:"config"`
+	// Descriptors contains the compressed sizes from a Schema 2/OCI manifest.
+	Descriptors []ManifestDescriptor `json:"layers"`
+	Layers      []LayerV1Compat
+	Config      ManifestDescriptor   `json:"config"`
+	Manifests   []ManifestDescriptor `json:"manifests"`
 }
 
 // ManifestDescriptor is used by Docker Schema 2 and OCI manifests to point
 // at the image configuration blob.
 type ManifestDescriptor struct {
 	Digest string `json:"digest"`
+	Size   int64  `json:"size"`
+}
+
+// imageSize returns the size represented by the manifest descriptors. A nil
+// result means that the registry did not provide usable size metadata.
+func (m ManifestV2) imageSize() *int64 {
+	var size int64
+	known := false
+	if m.Config.Size > 0 {
+		size += m.Config.Size
+		known = true
+	}
+	for _, descriptor := range m.Descriptors {
+		if descriptor.Size > 0 {
+			size += descriptor.Size
+			known = true
+		}
+	}
+	for _, layer := range m.Layers {
+		if layer.Size > 0 {
+			size += layer.Size
+			known = true
+		}
+	}
+	if !known {
+		return nil
+	}
+	return &size
 }
 
 type ImageConfig struct {

--- a/pkg/provider/registryv2/models.go
+++ b/pkg/provider/registryv2/models.go
@@ -23,11 +23,19 @@ type ManifestV2 struct {
 	Manifests   []ManifestDescriptor `json:"manifests"`
 }
 
-// ManifestDescriptor is used by Docker Schema 2 and OCI manifests to point
-// at the image configuration blob.
+// ManifestDescriptor is used by Docker Schema 2 and OCI manifests to point at
+// image config, layer, and platform descriptors.
 type ManifestDescriptor struct {
-	Digest string `json:"digest"`
-	Size   int64  `json:"size"`
+	Digest   string    `json:"digest"`
+	Size     *int64    `json:"size"`
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform identifies the runnable OS and architecture of an image.
+type Platform struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	Variant      string `json:"variant,omitempty"`
 }
 
 // imageSize returns the size represented by the manifest descriptors. A nil
@@ -35,21 +43,26 @@ type ManifestDescriptor struct {
 func (m ManifestV2) imageSize() *int64 {
 	var size int64
 	known := false
-	if m.Config.Size > 0 {
-		size += m.Config.Size
+	if m.Config.Digest != "" {
+		if m.Config.Size == nil || *m.Config.Size < 0 {
+			return nil
+		}
+		size += *m.Config.Size
 		known = true
 	}
 	for _, descriptor := range m.Descriptors {
-		if descriptor.Size > 0 {
-			size += descriptor.Size
-			known = true
+		if descriptor.Size == nil || *descriptor.Size < 0 {
+			return nil
 		}
+		size += *descriptor.Size
+		known = true
 	}
 	for _, layer := range m.Layers {
-		if layer.Size > 0 {
-			size += layer.Size
-			known = true
+		if layer.Size <= 0 {
+			return nil
 		}
+		size += layer.Size
+		known = true
 	}
 	if !known {
 		return nil

--- a/pkg/provider/registryv2/models_test.go
+++ b/pkg/provider/registryv2/models_test.go
@@ -69,3 +69,19 @@ func TestLayerV1Compat_EmptyCmd(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, layer.GetCommands())
 }
+
+func TestManifestV2_ImageSize(t *testing.T) {
+	manifest := ManifestV2{
+		Config:      ManifestDescriptor{Size: 17},
+		Descriptors: []ManifestDescriptor{{Size: 83}},
+	}
+
+	size := manifest.imageSize()
+	require.NotNil(t, size)
+	assert.Equal(t, int64(100), *size)
+}
+
+func TestManifestV2_ImageSizeWithoutMetadata(t *testing.T) {
+	assert.Nil(t, (ManifestV2{}).imageSize())
+	assert.Nil(t, (ManifestV2{Config: ManifestDescriptor{Size: 0}}).imageSize())
+}

--- a/pkg/provider/registryv2/models_test.go
+++ b/pkg/provider/registryv2/models_test.go
@@ -72,8 +72,8 @@ func TestLayerV1Compat_EmptyCmd(t *testing.T) {
 
 func TestManifestV2_ImageSize(t *testing.T) {
 	manifest := ManifestV2{
-		Config:      ManifestDescriptor{Size: 17},
-		Descriptors: []ManifestDescriptor{{Size: 83}},
+		Config:      ManifestDescriptor{Digest: "config", Size: int64Ptr(17)},
+		Descriptors: []ManifestDescriptor{{Digest: "layer", Size: int64Ptr(83)}},
 	}
 
 	size := manifest.imageSize()
@@ -83,5 +83,23 @@ func TestManifestV2_ImageSize(t *testing.T) {
 
 func TestManifestV2_ImageSizeWithoutMetadata(t *testing.T) {
 	assert.Nil(t, (ManifestV2{}).imageSize())
-	assert.Nil(t, (ManifestV2{Config: ManifestDescriptor{Size: 0}}).imageSize())
+	assert.Nil(t, (ManifestV2{Config: ManifestDescriptor{Digest: "config"}}).imageSize())
 }
+
+func TestManifestV2_ImageSizeWithoutLayerMetadata(t *testing.T) {
+	manifest := ManifestV2{
+		Config:      ManifestDescriptor{Digest: "config", Size: int64Ptr(17)},
+		Descriptors: []ManifestDescriptor{{Digest: "layer"}},
+	}
+	assert.Nil(t, manifest.imageSize())
+}
+
+func TestManifestV2_ImageSizeWithoutConfigMetadata(t *testing.T) {
+	manifest := ManifestV2{
+		Config:      ManifestDescriptor{Digest: "config"},
+		Descriptors: []ManifestDescriptor{{Digest: "layer", Size: int64Ptr(83)}},
+	}
+	assert.Nil(t, manifest.imageSize())
+}
+
+func int64Ptr(value int64) *int64 { return &value }

--- a/pkg/provider/registryv2/scenario_provider.go
+++ b/pkg/provider/registryv2/scenario_provider.go
@@ -445,6 +445,23 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	if err = json.Unmarshal(*body, &manifestV2); err != nil {
 		return nil, err
 	}
+	// Resolve an OCI image index or Docker manifest list before extracting
+	// labels and sizes. The selected platform manifest is authoritative.
+	if len(manifestV2.Manifests) > 0 {
+		selected := manifestV2.Manifests[0]
+		if selected.Digest == "" {
+			return nil, fmt.Errorf("image index contains no usable manifest descriptor")
+		}
+		manifestURI := strings.TrimSuffix(dataSource, "/manifests/"+foundScenario.Name) + "/manifests/" + selected.Digest
+		body, err = s.queryRegistry(manifestURI, registry.Username, registry.Password, registry.Token, "GET", registry.SkipTLS)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve selected image manifest %s: %w", selected.Digest, err)
+		}
+		manifestV2 = ManifestV2{}
+		if err = json.Unmarshal(*body, &manifestV2); err != nil {
+			return nil, err
+		}
+	}
 	for _, l := range manifestV2.RawLayers {
 		layer := LayerV1Compat{}
 		if err = json.Unmarshal([]byte(l["v1Compatibility"]), &layer); err != nil {
@@ -469,6 +486,9 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	scenarioDetail := models.ScenarioDetail{
 		ScenarioTag: *foundScenario,
 	}
+	// Generic registry tag listings contain names only; use the resolved
+	// manifest as the authoritative source for image size.
+	scenarioDetail.Size = manifestV2.imageSize()
 	var titleLabel = ""
 	var descriptionLabel = ""
 	var inputFieldsLabel = ""

--- a/pkg/provider/registryv2/scenario_provider.go
+++ b/pkg/provider/registryv2/scenario_provider.go
@@ -448,9 +448,20 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	// Resolve an OCI image index or Docker manifest list before extracting
 	// labels and sizes. The selected platform manifest is authoritative.
 	if len(manifestV2.Manifests) > 0 {
-		selected := manifestV2.Manifests[0]
-		if selected.Digest == "" {
-			return nil, fmt.Errorf("image index contains no usable manifest descriptor")
+		var selected *ManifestDescriptor
+		for i := range manifestV2.Manifests {
+			descriptor := &manifestV2.Manifests[i]
+			if descriptor.Digest == "" || descriptor.Platform == nil {
+				continue
+			}
+			platform := descriptor.Platform
+			if registry.HasPlatform(platform.OS + "/" + platform.Architecture) {
+				selected = descriptor
+				break
+			}
+		}
+		if selected == nil {
+			return nil, fmt.Errorf("image index contains no manifest for platform %s", registry.GetPlatform())
 		}
 		manifestURI := strings.TrimSuffix(dataSource, "/manifests/"+foundScenario.Name) + "/manifests/" + selected.Digest
 		body, err = s.queryRegistry(manifestURI, registry.Username, registry.Password, registry.Token, "GET", registry.SkipTLS)
@@ -469,6 +480,7 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 		}
 		manifestV2.Layers = append(manifestV2.Layers, layer)
 	}
+	imageSize := manifestV2.imageSize()
 	if manifestV2.Config.Digest != "" {
 		configURI := strings.TrimSuffix(dataSource, "/manifests/"+foundScenario.Name) + "/blobs/" + manifestV2.Config.Digest
 		configBody, err := s.queryRegistry(configURI, registry.Username, registry.Password, registry.Token, "GET", registry.SkipTLS)
@@ -488,7 +500,7 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 	}
 	// Generic registry tag listings contain names only; use the resolved
 	// manifest as the authoritative source for image size.
-	scenarioDetail.Size = manifestV2.imageSize()
+	scenarioDetail.Size = imageSize
 	var titleLabel = ""
 	var descriptionLabel = ""
 	var inputFieldsLabel = ""

--- a/pkg/provider/registryv2/scenario_provider.go
+++ b/pkg/provider/registryv2/scenario_provider.go
@@ -455,7 +455,7 @@ func (s *ScenarioProvider) getScenarioDetail(dataSource string, foundScenario *m
 				continue
 			}
 			platform := descriptor.Platform
-			if registry.HasPlatform(platform.OS + "/" + platform.Architecture) {
+			if registry.MatchesPlatform(platform.OS, platform.Architecture, platform.Variant) {
 				selected = descriptor
 				break
 			}

--- a/pkg/provider/registryv2/scenario_provider_test.go
+++ b/pkg/provider/registryv2/scenario_provider_test.go
@@ -237,7 +237,7 @@ func TestScenarioProvider_GetScenarioDetail_Schema2ConfigLabels(t *testing.T) {
 	}))
 	defer server.Close()
 
-	registry := models.RegistryV2{RegistryURL: server.URL, ScenarioRepository: "repo"}
+	registry := models.RegistryV2{RegistryURL: server.URL, ScenarioRepository: "repo", Platform: "linux/amd64"}
 	foundScenario := &models.ScenarioTag{Name: "dummy-scenario"}
 	result, err := p.getScenarioDetail(server.URL+"/v2/repo/manifests/dummy-scenario", foundScenario, false, &registry)
 
@@ -266,7 +266,11 @@ func TestScenarioProvider_GetScenarioDetail_ManifestIndex(t *testing.T) {
 		case "/v2/repo/manifests/dummy-scenario":
 			_, _ = w.Write([]byte(`{
 				"schemaVersion": 2,
-				"manifests": [{"digest": "sha256:selected", "size": 999}]
+				"manifests": [
+					{"digest": "", "platform": {"os": "linux", "architecture": "amd64"}},
+					{"digest": "sha256:wrong", "platform": {"os": "linux", "architecture": "arm64"}},
+					{"digest": "sha256:selected", "platform": {"os": "linux", "architecture": "amd64"}}
+				]
 			}`))
 		case "/v2/repo/manifests/sha256:selected":
 			_, _ = w.Write([]byte(`{
@@ -286,7 +290,7 @@ func TestScenarioProvider_GetScenarioDetail_ManifestIndex(t *testing.T) {
 	}))
 	defer server.Close()
 
-	registry := models.RegistryV2{RegistryURL: server.URL, ScenarioRepository: "repo"}
+	registry := models.RegistryV2{RegistryURL: server.URL, ScenarioRepository: "repo", Platform: "linux/amd64"}
 	result, err := p.getScenarioDetail(server.URL+"/v2/repo/manifests/dummy-scenario", &models.ScenarioTag{Name: "dummy-scenario"}, false, &registry)
 
 	require.NoError(t, err)

--- a/pkg/provider/registryv2/scenario_provider_test.go
+++ b/pkg/provider/registryv2/scenario_provider_test.go
@@ -217,8 +217,8 @@ func TestScenarioProvider_GetScenarioDetail_Schema2ConfigLabels(t *testing.T) {
 			_, _ = w.Write([]byte(`{
 				"schemaVersion": 2,
 				"mediaType": "application/vnd.oci.image.manifest.v1+json",
-				"config": {"digest": "sha256:config"},
-				"layers": []
+				"config": {"digest": "sha256:config", "size": 17},
+				"layers": [{"digest": "sha256:layer", "size": 83}]
 			}`))
 		case "/v2/repo/blobs/sha256:config":
 			configRequested = true
@@ -247,8 +247,52 @@ func TestScenarioProvider_GetScenarioDetail_Schema2ConfigLabels(t *testing.T) {
 	assert.Equal(t, "Modern Scenario", result.Title)
 	assert.Equal(t, "Schema 2 image", result.Description)
 	assert.Empty(t, result.Fields)
+	require.NotNil(t, result.Size)
+	assert.Equal(t, int64(100), *result.Size)
 	assert.True(t, result.IsAScenario)
 	assert.True(t, result.HasRollback)
+}
+
+func TestScenarioProvider_GetScenarioDetail_ManifestIndex(t *testing.T) {
+	config := getConfig(t)
+	p := ScenarioProvider{provider.BaseScenarioProvider{
+		Config: config,
+		Cache:  cache.NewCache(),
+	}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/repo/manifests/dummy-scenario":
+			_, _ = w.Write([]byte(`{
+				"schemaVersion": 2,
+				"manifests": [{"digest": "sha256:selected", "size": 999}]
+			}`))
+		case "/v2/repo/manifests/sha256:selected":
+			_, _ = w.Write([]byte(`{
+				"schemaVersion": 2,
+				"config": {"digest": "sha256:config", "size": 2},
+				"layers": [{"digest": "sha256:layer", "size": 40}]
+			}`))
+		case "/v2/repo/blobs/sha256:config":
+			_, _ = w.Write([]byte(`{"config":{"Labels":{
+				"krknctl.title":"Indexed Scenario",
+				"krknctl.description":"Indexed image",
+				"krknctl.input_fields":"[]"
+			}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registry := models.RegistryV2{RegistryURL: server.URL, ScenarioRepository: "repo"}
+	result, err := p.getScenarioDetail(server.URL+"/v2/repo/manifests/dummy-scenario", &models.ScenarioTag{Name: "dummy-scenario"}, false, &registry)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Size)
+	assert.Equal(t, int64(42), *result.Size)
 }
 
 func TestScenarioProvider_GetGlobalEnvironment(t *testing.T) {

--- a/pkg/provider/signatures.go
+++ b/pkg/provider/signatures.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"sync"
+
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/krkn-chaos/krknctl/pkg/verify"
+)
+
+const signatureWorkers = 8
+
+// VerifyImageSignatures verifies a batch of scenario tags with bounded
+// concurrency. Tags sharing a digest are verified once and receive the same
+// result. Operational verification failures are represented as unknown.
+func VerifyImageSignatures(ctx context.Context, dataProvider ScenarioDataProvider, registry *models.RegistryV2, tags []models.ScenarioTag) ([]verify.SignatureStatus, error) {
+	statuses := make([]verify.SignatureStatus, len(tags))
+	if len(tags) == 0 {
+		return statuses, nil
+	}
+
+	unique := make(map[string]models.ScenarioTag)
+	keys := make([]string, len(tags))
+	for i, tag := range tags {
+		key := tag.Name
+		if tag.Digest != nil && *tag.Digest != "" {
+			key = "digest:" + *tag.Digest
+		}
+		keys[i] = key
+		unique[key] = tag
+	}
+
+	type result struct {
+		key    string
+		status verify.SignatureStatus
+	}
+	jobs := make(chan string)
+	results := make(chan result, len(unique))
+	workerCount := signatureWorkers
+	if len(unique) < workerCount {
+		workerCount = len(unique)
+	}
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case key, ok := <-jobs:
+					if !ok {
+						return
+					}
+					status, err := dataProvider.GetImageSignatureStatus(ctx, registry, unique[key])
+					if err != nil || status == "" {
+						status = verify.SignatureUnknown
+					}
+					results <- result{key: key, status: status}
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for key := range unique {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- key:
+			}
+		}
+	}()
+	workers.Wait()
+	close(results)
+	resolved := make(map[string]verify.SignatureStatus, len(unique))
+	for item := range results {
+		resolved[item.key] = item.status
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for i, key := range keys {
+		statuses[i] = resolved[key]
+	}
+	return statuses, nil
+}

--- a/pkg/provider/signatures_test.go
+++ b/pkg/provider/signatures_test.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/krkn-chaos/krknctl/pkg/provider/models"
+	"github.com/krkn-chaos/krknctl/pkg/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type batchSignatureProvider struct {
+	calls atomic.Int32
+}
+
+func (p *batchSignatureProvider) GetRegistryImages(*models.RegistryV2) (*[]models.ScenarioTag, error) {
+	return nil, nil
+}
+
+func (p *batchSignatureProvider) GetGlobalEnvironment(*models.RegistryV2, string) (*models.ScenarioDetail, error) {
+	return nil, nil
+}
+
+func (p *batchSignatureProvider) GetScenarioDetail(string, *models.RegistryV2) (*models.ScenarioDetail, error) {
+	return nil, nil
+}
+
+func (p *batchSignatureProvider) GetImageSignatureStatus(_ context.Context, _ *models.RegistryV2, _ models.ScenarioTag) (verify.SignatureStatus, error) {
+	p.calls.Add(1)
+	return verify.SignatureSigned, nil
+}
+
+func (p *batchSignatureProvider) ScaffoldScenarios([]string, bool, *models.RegistryV2, bool, *ScaffoldSeed) (*string, error) {
+	return nil, nil
+}
+
+func TestVerifyImageSignaturesDeduplicatesDigestTags(t *testing.T) {
+	dataProvider := &batchSignatureProvider{}
+	digest := "sha256:shared"
+	tags := []models.ScenarioTag{
+		{Name: "latest", Digest: &digest},
+		{Name: "stable", Digest: &digest},
+	}
+
+	statuses, err := VerifyImageSignatures(context.Background(), dataProvider, nil, tags)
+	require.NoError(t, err)
+	assert.Equal(t, []verify.SignatureStatus{verify.SignatureSigned, verify.SignatureSigned}, statuses)
+	assert.Equal(t, int32(1), dataProvider.calls.Load())
+}
+
+func TestVerifyImageSignaturesReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := VerifyImageSignatures(ctx, &batchSignatureProvider{}, nil, []models.ScenarioTag{{Name: "scenario"}})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestVerifyImageSignaturesMapsProviderErrorsToUnknown(t *testing.T) {
+	dataProvider := &errorSignatureProvider{}
+	statuses, err := VerifyImageSignatures(context.Background(), dataProvider, nil, []models.ScenarioTag{{Name: "scenario"}})
+	require.NoError(t, err)
+	assert.Equal(t, []verify.SignatureStatus{verify.SignatureUnknown}, statuses)
+}
+
+type errorSignatureProvider struct{ batchSignatureProvider }
+
+func (p *errorSignatureProvider) GetImageSignatureStatus(context.Context, *models.RegistryV2, models.ScenarioTag) (verify.SignatureStatus, error) {
+	return verify.SignatureUnknown, errors.New("verification unavailable")
+}


### PR DESCRIPTION
## Summary

Registry tag listings do not always expose image size. This is common with private Docker Registry v2 repositories and multi-architecture images, which caused scenario metadata to return an empty size.

This PR makes the provider layer the single source of truth for image size:

- Populate `ScenarioDetail.Size` from the resolved image manifest.
- Calculate Registry v2 image size from config and layer descriptor sizes.
- Resolve OCI image indexes and Docker manifest lists for the requested platform.
- Preserve Quay multi-architecture semantics by using the selected platform manifest size.
- Keep `GetRegistryImages` focused on tag discovery.

The CLI scenario listing now also verifies and displays each image signature status (`signed`, `unsigned`, `untrusted`, or `unknown`) with bounded concurrency. Verification failures are reported as `unknown` and do not hide other scenarios.

## Validation

```text
CGO_ENABLED=0 go test -tags containers_image_openpgp ./pkg/provider/...
CGO_ENABLED=0 go test -tags containers_image_openpgp ./cmd -run TestPopulateScenarioSignatureStatuses -count=1
```

Result: provider tests and signature-listing regression tests passed.