### PR TITLE
ci: cancel superseded test workflow runs

### DIFF
--- a/.github/workflows/require-docs.yml
+++ b/.github/workflows/require-docs.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, edited, synchronize]
     branches:
         - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   check-docs:
     name: Check Documentation Update

--- a/.github/workflows/test-operator.yaml
+++ b/.github/workflows/test-operator.yaml
@@ -1,6 +1,9 @@
 name: krknctl operator test
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   operator-install-uninstall:
     name: operator install and uninstall

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: krknctl test
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: krknctl test
@@ -114,4 +117,3 @@ jobs:
           git commit -m "[KRKN] Coverage Badge ${GITHUB_REF##*/}" || echo "no changes to commit"
           git push
           
-


### PR DESCRIPTION
## Description  
Stopping concurrent runs of the same pr when there are multi pushes

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).  

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  